### PR TITLE
feat: Phase 2 データ入力モジュール + 先生設定バグ修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,8 @@ next-env.d.ts
 # Electron
 main/
 
-# データフォルダ
-data/
+# データフォルダ (Electronランタイム用、app/data/は除外しない)
+/data/
 **/*.db
 **/*.db-shm
 **/*.db-wal

--- a/app/data/classes/page.tsx
+++ b/app/data/classes/page.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { useCallback } from "react"
+import { toast } from "sonner"
+
+import { PageHeader } from "@/components/layout/PageHeader"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useClasses } from "@/hooks/useClasses"
+
+export default function ClassesPage() {
+  const { classesByGrade, loading, updateClass } = useClasses()
+
+  const handleNameChange = useCallback(
+    async (classId: string, newName: string) => {
+      try {
+        await updateClass(classId, { name: newName })
+        toast.success("クラス名を更新しました")
+      } catch {
+        toast.error("更新に失敗しました")
+      }
+    },
+    [updateClass]
+  )
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="クラス設定"
+        description="学年・クラスの表示名を編集します。学級数は「学校基本設定」で変更できます。"
+      />
+
+      <div className="space-y-6 p-6">
+        {classesByGrade.length === 0 ? (
+          <Card>
+            <CardContent className="text-muted-foreground py-8 text-center">
+              学年・クラスがまだ作成されていません。
+              「学校基本設定」で学級構成を保存してください。
+            </CardContent>
+          </Card>
+        ) : (
+          classesByGrade.map(({ grade, classes }) => (
+            <Card key={grade.id}>
+              <CardHeader>
+                <CardTitle>{grade.name}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-16">#</TableHead>
+                      <TableHead>クラス名</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {classes.map((cls, index) => (
+                      <TableRow key={cls.id}>
+                        <TableCell className="text-muted-foreground">
+                          {index + 1}
+                        </TableCell>
+                        <TableCell>
+                          <Input
+                            defaultValue={cls.name}
+                            onBlur={(e) => {
+                              if (e.target.value !== cls.name) {
+                                handleNameChange(cls.id, e.target.value)
+                              }
+                            }}
+                            className="h-8 w-40"
+                          />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                    {classes.length === 0 && (
+                      <TableRow>
+                        <TableCell
+                          colSpan={2}
+                          className="text-muted-foreground py-4 text-center"
+                        >
+                          クラスがありません
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/data/duties/page.tsx
+++ b/app/data/duties/page.tsx
@@ -1,0 +1,416 @@
+"use client"
+
+import { Plus, Trash2 } from "lucide-react"
+import { useCallback, useEffect, useState } from "react"
+import { toast } from "sonner"
+
+import { PageHeader } from "@/components/layout/PageHeader"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useDuties } from "@/hooks/useDuties"
+import { useSchool } from "@/hooks/useSchool"
+import { useTeachers } from "@/hooks/useTeachers"
+import { DAY_NAMES } from "@/lib/constants"
+import type { Duty } from "@/types/common.types"
+
+export default function DutiesPage() {
+  const {
+    duties,
+    loading,
+    createDuty,
+    updateDuty,
+    deleteDuty,
+    setTeachersForDuty,
+  } = useDuties()
+  const { school } = useSchool()
+  const { teachers } = useTeachers()
+
+  const [selectedDutyId, setSelectedDutyId] = useState<string | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [formName, setFormName] = useState("")
+  const [formShortName, setFormShortName] = useState("")
+  const [formDayOfWeek, setFormDayOfWeek] = useState(0)
+  const [formPeriod, setFormPeriod] = useState(1)
+
+  const selectedDuty = duties.find((d) => d.id === selectedDutyId)
+
+  useEffect(() => {
+    if (duties.length > 0 && !selectedDutyId) {
+      setSelectedDutyId(duties[0].id)
+    }
+  }, [duties, selectedDutyId])
+
+  const handleCreateDuty = useCallback(async () => {
+    if (!formName.trim()) {
+      toast.error("校務名を入力してください")
+      return
+    }
+    try {
+      const created = await createDuty({
+        name: formName,
+        shortName: formShortName,
+        dayOfWeek: formDayOfWeek,
+        period: formPeriod,
+      })
+      setSelectedDutyId(created.id)
+      setDialogOpen(false)
+      setFormName("")
+      setFormShortName("")
+      setFormDayOfWeek(0)
+      setFormPeriod(1)
+      toast.success("校務を追加しました")
+    } catch {
+      toast.error("追加に失敗しました")
+    }
+  }, [formName, formShortName, formDayOfWeek, formPeriod, createDuty])
+
+  const handleDeleteDuty = useCallback(
+    async (duty: Duty) => {
+      try {
+        await deleteDuty(duty.id)
+        if (selectedDutyId === duty.id) {
+          setSelectedDutyId(null)
+        }
+        toast.success("校務を削除しました")
+      } catch {
+        toast.error("削除に失敗しました")
+      }
+    },
+    [deleteDuty, selectedDutyId]
+  )
+
+  const handleUpdateField = useCallback(
+    async (field: string, value: unknown) => {
+      if (!selectedDuty) return
+      try {
+        await updateDuty(selectedDuty.id, { [field]: value })
+      } catch {
+        toast.error("更新に失敗しました")
+      }
+    },
+    [selectedDuty, updateDuty]
+  )
+
+  const handleTeacherToggle = useCallback(
+    async (teacherId: string, checked: boolean) => {
+      if (!selectedDuty) return
+      const currentTeacherIds =
+        selectedDuty.teacherDuties?.map((td) => td.teacherId) ?? []
+      const newTeacherIds = checked
+        ? [...currentTeacherIds, teacherId]
+        : currentTeacherIds.filter((id) => id !== teacherId)
+      try {
+        await setTeachersForDuty(selectedDuty.id, newTeacherIds)
+      } catch {
+        toast.error("担当先生の更新に失敗しました")
+      }
+    },
+    [selectedDuty, setTeachersForDuty]
+  )
+
+  const daysPerWeek = school?.daysPerWeek ?? 5
+  const maxPeriods = school?.maxPeriodsPerDay ?? 6
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader
+        title="校務設定"
+        description="校務の情報と担当先生を設定します"
+      >
+        <Button onClick={() => setDialogOpen(true)}>
+          <Plus className="mr-1 h-4 w-4" />
+          校務を追加
+        </Button>
+      </PageHeader>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* 左: 校務リスト */}
+        <div className="w-56 border-r">
+          <ScrollArea className="h-full">
+            <div className="space-y-1 p-2">
+              {duties.map((duty) => (
+                <div
+                  key={duty.id}
+                  role="button"
+                  tabIndex={0}
+                  className={`group flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                    selectedDutyId === duty.id
+                      ? "bg-accent font-medium"
+                      : "hover:bg-accent/50"
+                  }`}
+                  onClick={() => setSelectedDutyId(duty.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") setSelectedDutyId(duty.id)
+                  }}
+                >
+                  <div>
+                    <span>{duty.name}</span>
+                    <span className="text-muted-foreground ml-1 text-xs">
+                      ({DAY_NAMES[duty.dayOfWeek]}{duty.period})
+                    </span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleDeleteDuty(duty)
+                    }}
+                  >
+                    <Trash2 className="text-destructive h-3 w-3" />
+                  </Button>
+                </div>
+              ))}
+              {duties.length === 0 && (
+                <p className="text-muted-foreground py-4 text-center text-xs">
+                  校務がありません
+                </p>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* 右: 詳細 */}
+        <div className="flex-1 overflow-auto">
+          {selectedDuty ? (
+            <div className="p-6">
+              <Tabs defaultValue="info">
+                <TabsList>
+                  <TabsTrigger value="info">基本情報</TabsTrigger>
+                  <TabsTrigger value="teachers">担当先生</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="info" className="mt-4 space-y-4">
+                  <Card>
+                    <CardContent className="space-y-4 pt-6">
+                      <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                          <Label>校務名</Label>
+                          <Input
+                            key={selectedDuty.id + "-name"}
+                            defaultValue={selectedDuty.name}
+                            onBlur={(e) =>
+                              handleUpdateField("name", e.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label>略名</Label>
+                          <Input
+                            key={selectedDuty.id + "-shortName"}
+                            defaultValue={selectedDuty.shortName}
+                            onBlur={(e) =>
+                              handleUpdateField("shortName", e.target.value)
+                            }
+                          />
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                          <Label>曜日</Label>
+                          <Select
+                            value={String(selectedDuty.dayOfWeek)}
+                            onValueChange={(v) =>
+                              handleUpdateField("dayOfWeek", parseInt(v))
+                            }
+                          >
+                            <SelectTrigger>
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {DAY_NAMES.slice(0, daysPerWeek).map(
+                                (day, i) => (
+                                  <SelectItem key={i} value={String(i)}>
+                                    {day}
+                                  </SelectItem>
+                                )
+                              )}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="space-y-2">
+                          <Label>時限</Label>
+                          <Select
+                            value={String(selectedDuty.period)}
+                            onValueChange={(v) =>
+                              handleUpdateField("period", parseInt(v))
+                            }
+                          >
+                            <SelectTrigger>
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {Array.from(
+                                { length: maxPeriods },
+                                (_, i) => i + 1
+                              ).map((p) => (
+                                <SelectItem key={p} value={String(p)}>
+                                  {p}時限
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+
+                <TabsContent value="teachers" className="mt-4">
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>担当先生</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-2">
+                        {teachers.map((teacher) => {
+                          const isAssigned =
+                            selectedDuty.teacherDuties?.some(
+                              (td) => td.teacherId === teacher.id
+                            ) ?? false
+                          return (
+                            <div
+                              key={teacher.id}
+                              className="flex items-center gap-2"
+                            >
+                              <Checkbox
+                                id={`teacher-${teacher.id}`}
+                                checked={isAssigned}
+                                onCheckedChange={(checked) =>
+                                  handleTeacherToggle(
+                                    teacher.id,
+                                    checked === true
+                                  )
+                                }
+                              />
+                              <Label
+                                htmlFor={`teacher-${teacher.id}`}
+                                className="cursor-pointer"
+                              >
+                                {teacher.name}
+                              </Label>
+                            </div>
+                          )
+                        })}
+                        {teachers.length === 0 && (
+                          <p className="text-muted-foreground text-sm">
+                            先生が登録されていません
+                          </p>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+              </Tabs>
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <p className="text-muted-foreground">
+                左のリストから校務を選択してください
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>校務を追加</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>校務名</Label>
+              <Input
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
+                placeholder="例: 給食指導"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>略名</Label>
+              <Input
+                value={formShortName}
+                onChange={(e) => setFormShortName(e.target.value)}
+                placeholder="例: 給"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>曜日</Label>
+                <Select
+                  value={String(formDayOfWeek)}
+                  onValueChange={(v) => setFormDayOfWeek(parseInt(v))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {DAY_NAMES.slice(0, daysPerWeek).map((day, i) => (
+                      <SelectItem key={i} value={String(i)}>
+                        {day}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>時限</Label>
+                <Select
+                  value={String(formPeriod)}
+                  onValueChange={(v) => setFormPeriod(parseInt(v))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Array.from({ length: maxPeriods }, (_, i) => i + 1).map(
+                      (p) => (
+                        <SelectItem key={p} value={String(p)}>
+                          {p}時限
+                        </SelectItem>
+                      )
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setDialogOpen(false)}>
+                キャンセル
+              </Button>
+              <Button onClick={handleCreateDuty}>追加</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/app/data/koma/page.tsx
+++ b/app/data/koma/page.tsx
@@ -1,0 +1,884 @@
+"use client"
+
+import { Copy, Plus, Trash2 } from "lucide-react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import { PageHeader } from "@/components/layout/PageHeader"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useClasses } from "@/hooks/useClasses"
+import { useKomas } from "@/hooks/useKomas"
+import { useRooms } from "@/hooks/useRooms"
+import { useSubjects } from "@/hooks/useSubjects"
+import { useTeachers } from "@/hooks/useTeachers"
+import { KOMA_TEACHER_ROLES, KOMA_TYPES } from "@/lib/constants"
+import { CURRICULUM_PRESETS, generateKomasFromPreset } from "@/lib/komaGenerator"
+import type { Grade, Koma } from "@/types/common.types"
+
+export default function KomaPage() {
+  const { grades, classes } = useClasses()
+  const { subjects } = useSubjects()
+  const { teachers } = useTeachers()
+  const { rooms } = useRooms()
+
+  const [selectedGradeId, setSelectedGradeId] = useState<string | null>(null)
+
+  // selectedGradeId に基づいて useKomas を呼ぶ
+  const {
+    komas,
+    loading,
+    createKoma,
+    updateKoma,
+    deleteKoma,
+    duplicateKoma,
+    setKomaTeachers,
+    setKomaClasses,
+    setKomaRooms,
+    batchCreateKomas,
+    deleteKomasByGrade,
+  } = useKomas(selectedGradeId ?? undefined)
+
+  const [selectedKomaId, setSelectedKomaId] = useState<string | null>(null)
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const [batchDialogOpen, setBatchDialogOpen] = useState(false)
+
+  const selectedKoma = komas.find((k) => k.id === selectedKomaId)
+
+  // 学年が変わったら先頭の駒を選択
+  useEffect(() => {
+    if (grades.length > 0 && !selectedGradeId) {
+      setSelectedGradeId(grades[0].id)
+    }
+  }, [grades, selectedGradeId])
+
+  useEffect(() => {
+    setSelectedKomaId(null)
+  }, [selectedGradeId])
+
+  useEffect(() => {
+    if (komas.length > 0 && !selectedKomaId) {
+      setSelectedKomaId(komas[0].id)
+    }
+  }, [komas, selectedKomaId])
+
+  // 教科別にグループ化
+  const komasBySubject = useMemo(() => {
+    const groups: Record<string, { subject: { id: string; name: string; color: string }; komas: Koma[] }> = {}
+    for (const koma of komas) {
+      const subjectId = koma.subjectId
+      if (!groups[subjectId]) {
+        groups[subjectId] = {
+          subject: koma.subject ?? { id: subjectId, name: "不明", color: "#999" },
+          komas: [],
+        }
+      }
+      groups[subjectId].komas.push(koma)
+    }
+    return Object.values(groups)
+  }, [komas])
+
+  // 該当学年のクラス
+  const gradeClasses = useMemo(
+    () => classes.filter((c) => c.gradeId === selectedGradeId),
+    [classes, selectedGradeId]
+  )
+
+  const handleCreateKoma = useCallback(async () => {
+    if (!selectedGradeId || subjects.length === 0) return
+    try {
+      const created = await createKoma({
+        subjectId: subjects[0].id,
+        gradeId: selectedGradeId,
+      })
+      setSelectedKomaId(created.id)
+      setCreateDialogOpen(false)
+      toast.success("駒を追加しました")
+    } catch {
+      toast.error("追加に失敗しました")
+    }
+  }, [selectedGradeId, subjects, createKoma])
+
+  const handleDeleteKoma = useCallback(
+    async (koma: Koma) => {
+      try {
+        await deleteKoma(koma.id)
+        if (selectedKomaId === koma.id) {
+          setSelectedKomaId(null)
+        }
+        toast.success("駒を削除しました")
+      } catch {
+        toast.error("削除に失敗しました")
+      }
+    },
+    [deleteKoma, selectedKomaId]
+  )
+
+  const handleDuplicateKoma = useCallback(
+    async (koma: Koma) => {
+      try {
+        const duplicated = await duplicateKoma(koma.id)
+        if (duplicated) setSelectedKomaId(duplicated.id)
+        toast.success("駒をコピーしました")
+      } catch {
+        toast.error("コピーに失敗しました")
+      }
+    },
+    [duplicateKoma]
+  )
+
+  const handleUpdateField = useCallback(
+    async (field: string, value: unknown) => {
+      if (!selectedKoma) return
+      try {
+        await updateKoma(selectedKoma.id, { [field]: value })
+      } catch {
+        toast.error("更新に失敗しました")
+      }
+    },
+    [selectedKoma, updateKoma]
+  )
+
+  const handleTeacherToggle = useCallback(
+    async (teacherId: string, checked: boolean) => {
+      if (!selectedKoma) return
+      const current = selectedKoma.komaTeachers ?? []
+      const newTeachers = checked
+        ? [...current.map((kt) => ({ teacherId: kt.teacherId, role: kt.role })), { teacherId, role: "main" }]
+        : current
+            .filter((kt) => kt.teacherId !== teacherId)
+            .map((kt) => ({ teacherId: kt.teacherId, role: kt.role }))
+      try {
+        await setKomaTeachers(selectedKoma.id, newTeachers)
+      } catch {
+        toast.error("先生の設定に失敗しました")
+      }
+    },
+    [selectedKoma, setKomaTeachers]
+  )
+
+  const handleTeacherRoleChange = useCallback(
+    async (teacherId: string, role: string) => {
+      if (!selectedKoma) return
+      const current = selectedKoma.komaTeachers ?? []
+      const newTeachers = current.map((kt) => ({
+        teacherId: kt.teacherId,
+        role: kt.teacherId === teacherId ? role : kt.role,
+      }))
+      try {
+        await setKomaTeachers(selectedKoma.id, newTeachers)
+      } catch {
+        toast.error("役割の変更に失敗しました")
+      }
+    },
+    [selectedKoma, setKomaTeachers]
+  )
+
+  const handleClassToggle = useCallback(
+    async (classId: string, checked: boolean) => {
+      if (!selectedKoma) return
+      const currentIds = selectedKoma.komaClasses?.map((kc) => kc.classId) ?? []
+      const newIds = checked
+        ? [...currentIds, classId]
+        : currentIds.filter((id) => id !== classId)
+      try {
+        await setKomaClasses(selectedKoma.id, newIds)
+      } catch {
+        toast.error("クラスの設定に失敗しました")
+      }
+    },
+    [selectedKoma, setKomaClasses]
+  )
+
+  const handleRoomToggle = useCallback(
+    async (roomId: string, checked: boolean) => {
+      if (!selectedKoma) return
+      const currentIds = selectedKoma.komaRooms?.map((kr) => kr.roomId) ?? []
+      const newIds = checked
+        ? [...currentIds, roomId]
+        : currentIds.filter((id) => id !== roomId)
+      try {
+        await setKomaRooms(selectedKoma.id, newIds)
+      } catch {
+        toast.error("教室の設定に失敗しました")
+      }
+    },
+    [selectedKoma, setKomaRooms]
+  )
+
+  // 一括生成
+  const [batchGradeId, setBatchGradeId] = useState<string>("")
+  const [batchPreset, setBatchPreset] = useState<Record<string, { count: number; type: string; enabled: boolean }>>({})
+
+  const handleLoadPreset = useCallback(
+    (gradeNum: number) => {
+      const preset = CURRICULUM_PRESETS[gradeNum]
+      if (!preset) return
+      const map: Record<string, { count: number; type: string; enabled: boolean }> = {}
+      for (const item of preset) {
+        const subject = subjects.find((s) => s.name === item.subjectName)
+        if (subject) {
+          map[subject.id] = {
+            count: item.weeklyHours,
+            type: item.type ?? "normal",
+            enabled: true,
+          }
+        }
+      }
+      setBatchPreset(map)
+    },
+    [subjects]
+  )
+
+  const handleBatchGenerate = useCallback(async () => {
+    if (!batchGradeId) return
+    const grade = grades.find((g) => g.id === batchGradeId)
+    if (!grade) return
+
+    const komasToCreate = generateKomasFromPreset(
+      batchPreset,
+      batchGradeId,
+      subjects
+    )
+
+    if (komasToCreate.length === 0) {
+      toast.error("生成する駒がありません")
+      return
+    }
+
+    try {
+      await batchCreateKomas(komasToCreate)
+      setBatchDialogOpen(false)
+      toast.success(`${komasToCreate.length}件の駒を生成しました`)
+    } catch {
+      toast.error("一括生成に失敗しました")
+    }
+  }, [batchGradeId, batchPreset, grades, subjects, batchCreateKomas])
+
+  if (loading && grades.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader
+        title="駒設定"
+        description="各学年の教科駒を設定します"
+      >
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => setBatchDialogOpen(true)}>
+            一括生成
+          </Button>
+          <Button onClick={handleCreateKoma}>
+            <Plus className="mr-1 h-4 w-4" />
+            駒を追加
+          </Button>
+        </div>
+      </PageHeader>
+
+      {/* 学年タブ */}
+      <div className="border-b px-6">
+        <div className="flex gap-2">
+          {grades.map((grade) => (
+            <button
+              key={grade.id}
+              type="button"
+              className={`border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+                selectedGradeId === grade.id
+                  ? "border-primary text-primary"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+              onClick={() => setSelectedGradeId(grade.id)}
+            >
+              {grade.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* 左: 駒リスト (教科グループ別) */}
+        <div className="w-64 border-r">
+          <ScrollArea className="h-full">
+            <div className="p-2">
+              {komasBySubject.map((group) => (
+                <div key={group.subject.id} className="mb-3">
+                  <div className="mb-1 flex items-center gap-1 px-2">
+                    <div
+                      className="h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: group.subject.color }}
+                    />
+                    <span className="text-xs font-semibold">
+                      {group.subject.name}
+                    </span>
+                    <Badge variant="secondary" className="ml-auto text-[10px]">
+                      {group.komas.reduce((sum, k) => sum + k.count, 0)}h
+                    </Badge>
+                  </div>
+                  {group.komas.map((koma) => (
+                    <button
+                      key={koma.id}
+                      type="button"
+                      className={`flex w-full items-center justify-between rounded-md px-3 py-1.5 text-left text-sm transition-colors ${
+                        selectedKomaId === koma.id
+                          ? "bg-accent font-medium"
+                          : "hover:bg-accent/50"
+                      }`}
+                      onClick={() => setSelectedKomaId(koma.id)}
+                    >
+                      <span className="truncate">
+                        {koma.label || group.subject.name}
+                        {koma.type === "consecutive" && (
+                          <span className="text-muted-foreground ml-1 text-[10px]">
+                            (連続)
+                          </span>
+                        )}
+                      </span>
+                      <span className="text-muted-foreground text-xs">
+                        {koma.count}h
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              ))}
+              {komas.length === 0 && (
+                <p className="text-muted-foreground py-4 text-center text-xs">
+                  駒がありません
+                </p>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* 右: 詳細 */}
+        <div className="flex-1 overflow-auto">
+          {selectedKoma ? (
+            <div className="p-6">
+              <div className="mb-4 flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleDuplicateKoma(selectedKoma)}
+                >
+                  <Copy className="mr-1 h-3 w-3" />
+                  コピー
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive"
+                  onClick={() => handleDeleteKoma(selectedKoma)}
+                >
+                  <Trash2 className="mr-1 h-3 w-3" />
+                  削除
+                </Button>
+              </div>
+
+              <Tabs defaultValue="info">
+                <TabsList>
+                  <TabsTrigger value="info">基本情報</TabsTrigger>
+                  <TabsTrigger value="teachers">先生</TabsTrigger>
+                  <TabsTrigger value="classes">クラス</TabsTrigger>
+                  <TabsTrigger value="rooms">教室</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="info" className="mt-4 space-y-4">
+                  <Card>
+                    <CardContent className="space-y-4 pt-6">
+                      <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                          <Label>科目</Label>
+                          <Select
+                            value={selectedKoma.subjectId}
+                            onValueChange={(v) =>
+                              handleUpdateField("subjectId", v)
+                            }
+                          >
+                            <SelectTrigger>
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {subjects.map((s) => (
+                                <SelectItem key={s.id} value={s.id}>
+                                  {s.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="space-y-2">
+                          <Label>種類</Label>
+                          <RadioGroup
+                            value={selectedKoma.type}
+                            onValueChange={(v) =>
+                              handleUpdateField("type", v)
+                            }
+                            className="flex gap-4"
+                          >
+                            {Object.entries(KOMA_TYPES).map(([value, label]) => (
+                              <div
+                                key={value}
+                                className="flex items-center gap-1.5"
+                              >
+                                <RadioGroupItem value={value} id={`type-${value}`} />
+                                <Label htmlFor={`type-${value}`}>{label}</Label>
+                              </div>
+                            ))}
+                          </RadioGroup>
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-3 gap-4">
+                        <div className="space-y-2">
+                          <Label>駒数 (週)</Label>
+                          <Input
+                            key={selectedKoma.id + "-count"}
+                            type="number"
+                            min={0}
+                            max={10}
+                            defaultValue={selectedKoma.count}
+                            onBlur={(e) =>
+                              handleUpdateField(
+                                "count",
+                                parseInt(e.target.value) || 1
+                              )
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label>優先順位 (0-9)</Label>
+                          <Input
+                            key={selectedKoma.id + "-priority"}
+                            type="number"
+                            min={0}
+                            max={9}
+                            defaultValue={selectedKoma.priority}
+                            onBlur={(e) =>
+                              handleUpdateField(
+                                "priority",
+                                parseInt(e.target.value) || 5
+                              )
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label>ラベル</Label>
+                          <Input
+                            key={selectedKoma.id + "-label"}
+                            defaultValue={selectedKoma.label}
+                            onBlur={(e) =>
+                              handleUpdateField("label", e.target.value)
+                            }
+                            placeholder="任意"
+                          />
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+
+                <TabsContent value="teachers" className="mt-4">
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>担当先生</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-2">
+                        {teachers.map((teacher) => {
+                          const kt = selectedKoma.komaTeachers?.find(
+                            (kt) => kt.teacherId === teacher.id
+                          )
+                          const isAssigned = !!kt
+                          return (
+                            <div
+                              key={teacher.id}
+                              className="flex items-center gap-3"
+                            >
+                              <Checkbox
+                                id={`koma-teacher-${teacher.id}`}
+                                checked={isAssigned}
+                                onCheckedChange={(checked) =>
+                                  handleTeacherToggle(
+                                    teacher.id,
+                                    checked === true
+                                  )
+                                }
+                              />
+                              <Label
+                                htmlFor={`koma-teacher-${teacher.id}`}
+                                className="flex-1 cursor-pointer"
+                              >
+                                {teacher.name}
+                              </Label>
+                              {isAssigned && (
+                                <Select
+                                  value={kt.role}
+                                  onValueChange={(v) =>
+                                    handleTeacherRoleChange(teacher.id, v)
+                                  }
+                                >
+                                  <SelectTrigger className="w-20">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {Object.entries(KOMA_TEACHER_ROLES).map(
+                                      ([value, label]) => (
+                                        <SelectItem key={value} value={value}>
+                                          {label}
+                                        </SelectItem>
+                                      )
+                                    )}
+                                  </SelectContent>
+                                </Select>
+                              )}
+                            </div>
+                          )
+                        })}
+                        {teachers.length === 0 && (
+                          <p className="text-muted-foreground text-sm">
+                            先生が登録されていません
+                          </p>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+
+                <TabsContent value="classes" className="mt-4">
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>対象クラス</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-2">
+                        {gradeClasses.map((cls) => {
+                          const isAssigned =
+                            selectedKoma.komaClasses?.some(
+                              (kc) => kc.classId === cls.id
+                            ) ?? false
+                          return (
+                            <div
+                              key={cls.id}
+                              className="flex items-center gap-2"
+                            >
+                              <Checkbox
+                                id={`koma-class-${cls.id}`}
+                                checked={isAssigned}
+                                onCheckedChange={(checked) =>
+                                  handleClassToggle(cls.id, checked === true)
+                                }
+                              />
+                              <Label
+                                htmlFor={`koma-class-${cls.id}`}
+                                className="cursor-pointer"
+                              >
+                                {cls.name}
+                              </Label>
+                            </div>
+                          )
+                        })}
+                        {gradeClasses.length === 0 && (
+                          <p className="text-muted-foreground text-sm">
+                            この学年にクラスがありません
+                          </p>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+
+                <TabsContent value="rooms" className="mt-4">
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>使用教室</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-2">
+                        {rooms.map((room) => {
+                          const isAssigned =
+                            selectedKoma.komaRooms?.some(
+                              (kr) => kr.roomId === room.id
+                            ) ?? false
+                          return (
+                            <div
+                              key={room.id}
+                              className="flex items-center gap-2"
+                            >
+                              <Checkbox
+                                id={`koma-room-${room.id}`}
+                                checked={isAssigned}
+                                onCheckedChange={(checked) =>
+                                  handleRoomToggle(room.id, checked === true)
+                                }
+                              />
+                              <Label
+                                htmlFor={`koma-room-${room.id}`}
+                                className="cursor-pointer"
+                              >
+                                {room.name}
+                              </Label>
+                            </div>
+                          )
+                        })}
+                        {rooms.length === 0 && (
+                          <p className="text-muted-foreground text-sm">
+                            特別教室が登録されていません
+                          </p>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+              </Tabs>
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <p className="text-muted-foreground">
+                {komas.length > 0
+                  ? "左のリストから駒を選択してください"
+                  : "「駒を追加」または「一括生成」で駒を作成してください"}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 一括生成ダイアログ */}
+      <BatchGenerateDialog
+        open={batchDialogOpen}
+        onOpenChange={setBatchDialogOpen}
+        grades={grades}
+        subjects={subjects}
+        batchGradeId={batchGradeId}
+        setBatchGradeId={setBatchGradeId}
+        batchPreset={batchPreset}
+        setBatchPreset={setBatchPreset}
+        onLoadPreset={handleLoadPreset}
+        onGenerate={handleBatchGenerate}
+        onDeleteExisting={deleteKomasByGrade}
+      />
+
+      {/* 新規駒ダイアログ */}
+      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>駒を追加</DialogTitle>
+          </DialogHeader>
+          <p className="text-muted-foreground text-sm">
+            選択中の学年に新しい駒を追加します。追加後に詳細を設定してください。
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setCreateDialogOpen(false)}
+            >
+              キャンセル
+            </Button>
+            <Button onClick={handleCreateKoma}>追加</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+// 一括生成ダイアログ
+function BatchGenerateDialog({
+  open,
+  onOpenChange,
+  grades,
+  subjects,
+  batchGradeId,
+  setBatchGradeId,
+  batchPreset,
+  setBatchPreset,
+  onLoadPreset,
+  onGenerate,
+  onDeleteExisting,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  grades: Grade[]
+  subjects: { id: string; name: string }[]
+  batchGradeId: string
+  setBatchGradeId: (id: string) => void
+  batchPreset: Record<string, { count: number; type: string; enabled: boolean }>
+  setBatchPreset: (
+    preset: Record<string, { count: number; type: string; enabled: boolean }>
+  ) => void
+  onLoadPreset: (gradeNum: number) => void
+  onGenerate: () => void
+  onDeleteExisting: (gradeId: string) => Promise<void>
+}) {
+  const selectedGrade = grades.find((g) => g.id === batchGradeId)
+
+  const handleDeleteAndGenerate = useCallback(async () => {
+    if (batchGradeId) {
+      await onDeleteExisting(batchGradeId)
+    }
+    onGenerate()
+  }, [batchGradeId, onDeleteExisting, onGenerate])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>駒の一括生成</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="flex items-end gap-4">
+            <div className="flex-1 space-y-2">
+              <Label>対象学年</Label>
+              <Select value={batchGradeId} onValueChange={setBatchGradeId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="学年を選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  {grades.map((g) => (
+                    <SelectItem key={g.id} value={g.id}>
+                      {g.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (selectedGrade) onLoadPreset(selectedGrade.gradeNum)
+              }}
+              disabled={!selectedGrade}
+            >
+              プリセット読込
+            </Button>
+          </div>
+
+          {Object.keys(batchPreset).length > 0 && (
+            <div className="max-h-80 overflow-auto rounded border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted sticky top-0">
+                  <tr>
+                    <th className="p-2 text-left">教科</th>
+                    <th className="w-20 p-2 text-center">週時間</th>
+                    <th className="w-24 p-2 text-center">種類</th>
+                    <th className="w-16 p-2 text-center">生成</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {subjects
+                    .filter((s) => batchPreset[s.id])
+                    .map((subject) => {
+                      const preset = batchPreset[subject.id]
+                      return (
+                        <tr key={subject.id} className="border-t">
+                          <td className="p-2">{subject.name}</td>
+                          <td className="p-2 text-center">
+                            <Input
+                              type="number"
+                              min={0}
+                              max={10}
+                              className="h-7 w-16 text-center"
+                              value={preset.count}
+                              onChange={(e) => {
+                                setBatchPreset({
+                                  ...batchPreset,
+                                  [subject.id]: {
+                                    ...preset,
+                                    count: parseInt(e.target.value) || 0,
+                                  },
+                                })
+                              }}
+                            />
+                          </td>
+                          <td className="p-2 text-center">
+                            <Select
+                              value={preset.type}
+                              onValueChange={(v) => {
+                                setBatchPreset({
+                                  ...batchPreset,
+                                  [subject.id]: { ...preset, type: v },
+                                })
+                              }}
+                            >
+                              <SelectTrigger className="h-7 w-20">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {Object.entries(KOMA_TYPES).map(
+                                  ([value, label]) => (
+                                    <SelectItem key={value} value={value}>
+                                      {label}
+                                    </SelectItem>
+                                  )
+                                )}
+                              </SelectContent>
+                            </Select>
+                          </td>
+                          <td className="p-2 text-center">
+                            <Checkbox
+                              checked={preset.enabled}
+                              onCheckedChange={(checked) => {
+                                setBatchPreset({
+                                  ...batchPreset,
+                                  [subject.id]: {
+                                    ...preset,
+                                    enabled: checked === true,
+                                  },
+                                })
+                              }}
+                            />
+                          </td>
+                        </tr>
+                      )
+                    })}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              キャンセル
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteAndGenerate}
+              disabled={!batchGradeId || Object.keys(batchPreset).length === 0}
+            >
+              既存を削除して生成
+            </Button>
+            <Button
+              onClick={onGenerate}
+              disabled={!batchGradeId || Object.keys(batchPreset).length === 0}
+            >
+              追加生成
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/data/rooms/page.tsx
+++ b/app/data/rooms/page.tsx
@@ -1,0 +1,306 @@
+"use client"
+
+import { Plus, Trash2 } from "lucide-react"
+import { useCallback, useEffect, useState } from "react"
+import { toast } from "sonner"
+
+import { PageHeader } from "@/components/layout/PageHeader"
+import { AvailabilityGrid } from "@/components/timetable/AvailabilityGrid"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useRooms } from "@/hooks/useRooms"
+import { useSchool } from "@/hooks/useSchool"
+import type { SpecialRoom } from "@/types/common.types"
+
+export default function RoomsPage() {
+  const {
+    rooms,
+    loading,
+    createRoom,
+    updateRoom,
+    deleteRoom,
+    upsertAvailability,
+    fetchRooms,
+  } = useRooms()
+  const { school } = useSchool()
+
+  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [formName, setFormName] = useState("")
+  const [formShortName, setFormShortName] = useState("")
+
+  const selectedRoom = rooms.find((r) => r.id === selectedRoomId)
+
+  useEffect(() => {
+    if (rooms.length > 0 && !selectedRoomId) {
+      setSelectedRoomId(rooms[0].id)
+    }
+  }, [rooms, selectedRoomId])
+
+  const handleCreateRoom = useCallback(async () => {
+    if (!formName.trim()) {
+      toast.error("教室名を入力してください")
+      return
+    }
+    try {
+      const created = await createRoom({
+        name: formName,
+        shortName: formShortName,
+      })
+      setSelectedRoomId(created.id)
+      setDialogOpen(false)
+      setFormName("")
+      setFormShortName("")
+      toast.success("特別教室を追加しました")
+    } catch {
+      toast.error("追加に失敗しました")
+    }
+  }, [formName, formShortName, createRoom])
+
+  const handleDeleteRoom = useCallback(
+    async (room: SpecialRoom) => {
+      try {
+        await deleteRoom(room.id)
+        if (selectedRoomId === room.id) {
+          setSelectedRoomId(null)
+        }
+        toast.success("特別教室を削除しました")
+      } catch {
+        toast.error("削除に失敗しました")
+      }
+    },
+    [deleteRoom, selectedRoomId]
+  )
+
+  const handleUpdateField = useCallback(
+    async (field: string, value: unknown) => {
+      if (!selectedRoom) return
+      try {
+        await updateRoom(selectedRoom.id, { [field]: value })
+      } catch {
+        toast.error("更新に失敗しました")
+      }
+    },
+    [selectedRoom, updateRoom]
+  )
+
+  const handleAvailabilityToggle = useCallback(
+    async (dayOfWeek: number, period: number, newStatus: string) => {
+      if (!selectedRoom) return
+      try {
+        await upsertAvailability({
+          roomId: selectedRoom.id,
+          dayOfWeek,
+          period,
+          status: newStatus,
+        })
+        await fetchRooms()
+      } catch {
+        toast.error("都合の更新に失敗しました")
+      }
+    },
+    [selectedRoom, upsertAvailability, fetchRooms]
+  )
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader
+        title="特別教室設定"
+        description="特別教室の情報と使用可能時間を設定します"
+      >
+        <Button onClick={() => setDialogOpen(true)}>
+          <Plus className="mr-1 h-4 w-4" />
+          教室を追加
+        </Button>
+      </PageHeader>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* 左: 教室リスト */}
+        <div className="w-56 border-r">
+          <ScrollArea className="h-full">
+            <div className="space-y-1 p-2">
+              {rooms.map((room) => (
+                <div
+                  key={room.id}
+                  role="button"
+                  tabIndex={0}
+                  className={`group flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                    selectedRoomId === room.id
+                      ? "bg-accent font-medium"
+                      : "hover:bg-accent/50"
+                  }`}
+                  onClick={() => setSelectedRoomId(room.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") setSelectedRoomId(room.id)
+                  }}
+                >
+                  <span>{room.name}</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleDeleteRoom(room)
+                    }}
+                  >
+                    <Trash2 className="text-destructive h-3 w-3" />
+                  </Button>
+                </div>
+              ))}
+              {rooms.length === 0 && (
+                <p className="text-muted-foreground py-4 text-center text-xs">
+                  特別教室がありません
+                </p>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* 右: 詳細 */}
+        <div className="flex-1 overflow-auto">
+          {selectedRoom ? (
+            <div className="p-6">
+              <Tabs defaultValue="info">
+                <TabsList>
+                  <TabsTrigger value="info">基本情報</TabsTrigger>
+                  <TabsTrigger value="availability">都合</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="info" className="mt-4 space-y-4">
+                  <Card>
+                    <CardContent className="space-y-4 pt-6">
+                      <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                          <Label>教室名</Label>
+                          <Input
+                            key={selectedRoom.id + "-name"}
+                            defaultValue={selectedRoom.name}
+                            onBlur={(e) =>
+                              handleUpdateField("name", e.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label>略名</Label>
+                          <Input
+                            key={selectedRoom.id + "-shortName"}
+                            defaultValue={selectedRoom.shortName}
+                            onBlur={(e) =>
+                              handleUpdateField("shortName", e.target.value)
+                            }
+                          />
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                          <Label>収容人数</Label>
+                          <Input
+                            key={selectedRoom.id + "-capacity"}
+                            type="number"
+                            min={1}
+                            defaultValue={selectedRoom.capacity}
+                            onBlur={(e) =>
+                              handleUpdateField(
+                                "capacity",
+                                parseInt(e.target.value) || 40
+                              )
+                            }
+                          />
+                        </div>
+                      </div>
+                      <div className="space-y-2">
+                        <Label>備考</Label>
+                        <Input
+                          key={selectedRoom.id + "-notes"}
+                          defaultValue={selectedRoom.notes}
+                          onBlur={(e) =>
+                            handleUpdateField("notes", e.target.value)
+                          }
+                        />
+                      </div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+
+                <TabsContent value="availability" className="mt-4">
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>使用可能時間</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <AvailabilityGrid
+                        roomId={selectedRoom.id}
+                        daysPerWeek={school?.daysPerWeek ?? 5}
+                        maxPeriodsPerDay={school?.maxPeriodsPerDay ?? 6}
+                        hasZeroPeriod={school?.hasZeroPeriod ?? false}
+                        availabilities={selectedRoom.availabilities ?? []}
+                        onToggle={handleAvailabilityToggle}
+                      />
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+              </Tabs>
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <p className="text-muted-foreground">
+                左のリストから教室を選択してください
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>特別教室を追加</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>教室名</Label>
+              <Input
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
+                placeholder="例: 音楽室"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>略名</Label>
+              <Input
+                value={formShortName}
+                onChange={(e) => setFormShortName(e.target.value)}
+                placeholder="例: 音"
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setDialogOpen(false)}>
+                キャンセル
+              </Button>
+              <Button onClick={handleCreateRoom}>追加</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/app/data/teachers/page.tsx
+++ b/app/data/teachers/page.tsx
@@ -1,0 +1,418 @@
+"use client"
+
+import { Plus, Trash2, Briefcase } from "lucide-react"
+import { useCallback, useEffect, useState } from "react"
+import { toast } from "sonner"
+
+import { PageHeader } from "@/components/layout/PageHeader"
+import { AvailabilityGrid } from "@/components/timetable/AvailabilityGrid"
+import { TeacherKomaList } from "@/components/timetable/TeacherKomaList"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Badge } from "@/components/ui/badge"
+import { useSchool } from "@/hooks/useSchool"
+import { useSubjects } from "@/hooks/useSubjects"
+import { useTeachers } from "@/hooks/useTeachers"
+import type { Teacher } from "@/types/common.types"
+
+export default function TeachersPage() {
+  const {
+    teachers,
+    loading,
+    createTeacher,
+    updateTeacher,
+    deleteTeacher,
+    upsertAvailability,
+  } = useTeachers()
+  const { school } = useSchool()
+  const { subjects } = useSubjects()
+
+  const [selectedTeacherId, setSelectedTeacherId] = useState<string | null>(
+    null
+  )
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [formName, setFormName] = useState("")
+  const [formNameKana, setFormNameKana] = useState("")
+  const [formMaxPeriods, setFormMaxPeriods] = useState(25)
+
+  const selectedTeacher = teachers.find((t) => t.id === selectedTeacherId)
+
+  useEffect(() => {
+    if (teachers.length > 0 && !selectedTeacherId) {
+      setSelectedTeacherId(teachers[0].id)
+    }
+  }, [teachers, selectedTeacherId])
+
+  const handleCreateTeacher = useCallback(async () => {
+    if (!formName.trim()) {
+      toast.error("先生名を入力してください")
+      return
+    }
+    try {
+      const created = await createTeacher({
+        name: formName,
+        nameKana: formNameKana,
+        maxPeriodsPerWeek: formMaxPeriods,
+      })
+      setSelectedTeacherId(created.id)
+      setDialogOpen(false)
+      setFormName("")
+      setFormNameKana("")
+      setFormMaxPeriods(25)
+      toast.success("先生を追加しました")
+    } catch {
+      toast.error("追加に失敗しました")
+    }
+  }, [formName, formNameKana, formMaxPeriods, createTeacher])
+
+  const handleDeleteTeacher = useCallback(
+    async (teacher: Teacher) => {
+      try {
+        await deleteTeacher(teacher.id)
+        if (selectedTeacherId === teacher.id) {
+          setSelectedTeacherId(null)
+        }
+        toast.success("先生を削除しました")
+      } catch {
+        toast.error("削除に失敗しました")
+      }
+    },
+    [deleteTeacher, selectedTeacherId]
+  )
+
+  const handleUpdateField = useCallback(
+    async (field: string, value: unknown) => {
+      if (!selectedTeacher) return
+      try {
+        await updateTeacher(selectedTeacher.id, { [field]: value })
+      } catch {
+        toast.error("更新に失敗しました")
+      }
+    },
+    [selectedTeacher, updateTeacher]
+  )
+
+  const handleAvailabilityToggle = useCallback(
+    async (dayOfWeek: number, period: number, newStatus: string) => {
+      if (!selectedTeacher) return
+      try {
+        await upsertAvailability({
+          teacherId: selectedTeacher.id,
+          dayOfWeek,
+          period,
+          status: newStatus,
+        })
+      } catch {
+        toast.error("都合の更新に失敗しました")
+      }
+    },
+    [selectedTeacher, upsertAvailability]
+  )
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader
+        title="先生設定"
+        description="先生の情報、都合、担当科目を設定します"
+      >
+        <Button onClick={() => setDialogOpen(true)}>
+          <Plus className="mr-1 h-4 w-4" />
+          先生を追加
+        </Button>
+      </PageHeader>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* 左: 先生リスト */}
+        <div className="w-56 border-r">
+          <ScrollArea className="h-full">
+            <div className="space-y-1 p-2">
+              {teachers.map((teacher) => (
+                <div
+                  key={teacher.id}
+                  role="button"
+                  tabIndex={0}
+                  className={`group flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                    selectedTeacherId === teacher.id
+                      ? "bg-accent font-medium"
+                      : "hover:bg-accent/50"
+                  }`}
+                  onClick={() => setSelectedTeacherId(teacher.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") setSelectedTeacherId(teacher.id)
+                  }}
+                >
+                  <span>{teacher.name}</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleDeleteTeacher(teacher)
+                    }}
+                  >
+                    <Trash2 className="text-destructive h-3 w-3" />
+                  </Button>
+                </div>
+              ))}
+              {teachers.length === 0 && (
+                <p className="text-muted-foreground py-4 text-center text-xs">
+                  先生がいません
+                </p>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* 右: 詳細 */}
+        <div className="flex-1 overflow-auto">
+          {selectedTeacher ? (
+            <div className="p-6">
+              <Tabs defaultValue="info">
+                <TabsList>
+                  <TabsTrigger value="info">基本情報</TabsTrigger>
+                  <TabsTrigger value="availability">都合</TabsTrigger>
+                  <TabsTrigger value="subjects">持ち駒</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="info" className="mt-4 space-y-4">
+                  <Card>
+                    <CardContent className="space-y-4 pt-6">
+                      <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                          <Label>先生名</Label>
+                          <Input
+                            key={selectedTeacher.id + "-name"}
+                            defaultValue={selectedTeacher.name}
+                            onBlur={(e) =>
+                              handleUpdateField("name", e.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label>ふりがな</Label>
+                          <Input
+                            key={selectedTeacher.id + "-nameKana"}
+                            defaultValue={selectedTeacher.nameKana}
+                            onBlur={(e) =>
+                              handleUpdateField("nameKana", e.target.value)
+                            }
+                          />
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                          <Label>担当教科</Label>
+                          <Select
+                            value={selectedTeacher.mainSubjectId ?? "none"}
+                            onValueChange={(v) =>
+                              handleUpdateField(
+                                "mainSubjectId",
+                                v === "none" ? null : v
+                              )
+                            }
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder="選択してください" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="none">未設定</SelectItem>
+                              {subjects.map((s) => (
+                                <SelectItem key={s.id} value={s.id}>
+                                  {s.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="space-y-2">
+                          <Label>週当たり最大コマ数</Label>
+                          <Input
+                            key={selectedTeacher.id + "-maxPeriodsPerWeek"}
+                            type="number"
+                            min={1}
+                            max={40}
+                            defaultValue={selectedTeacher.maxPeriodsPerWeek}
+                            onBlur={(e) =>
+                              handleUpdateField(
+                                "maxPeriodsPerWeek",
+                                parseInt(e.target.value) || 25
+                              )
+                            }
+                          />
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                          <Label>連続授業の最大数</Label>
+                          <Input
+                            key={selectedTeacher.id + "-maxConsecutive"}
+                            type="number"
+                            min={1}
+                            max={10}
+                            defaultValue={selectedTeacher.maxConsecutive}
+                            onBlur={(e) =>
+                              handleUpdateField(
+                                "maxConsecutive",
+                                parseInt(e.target.value) || 6
+                              )
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label>1日の最大授業数</Label>
+                          <Input
+                            key={selectedTeacher.id + "-maxPerDay"}
+                            type="number"
+                            min={1}
+                            max={10}
+                            defaultValue={selectedTeacher.maxPerDay}
+                            onBlur={(e) =>
+                              handleUpdateField(
+                                "maxPerDay",
+                                parseInt(e.target.value) || 6
+                              )
+                            }
+                          />
+                        </div>
+                      </div>
+                      <div className="space-y-2">
+                        <Label>備考</Label>
+                        <Input
+                          key={selectedTeacher.id + "-notes"}
+                          defaultValue={selectedTeacher.notes}
+                          onBlur={(e) =>
+                            handleUpdateField("notes", e.target.value)
+                          }
+                        />
+                      </div>
+                      {(selectedTeacher.teacherDuties?.length ?? 0) > 0 && (
+                        <div className="space-y-2">
+                          <Label className="flex items-center gap-1">
+                            <Briefcase className="h-3.5 w-3.5" />
+                            携わる校務
+                          </Label>
+                          <div className="flex flex-wrap gap-2">
+                            {selectedTeacher.teacherDuties?.map((td) => (
+                              <Badge key={td.id} variant="secondary">
+                                {td.duty?.name ?? "不明"}
+                              </Badge>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+
+                <TabsContent value="availability" className="mt-4">
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>都合マトリクス</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <AvailabilityGrid
+                        teacherId={selectedTeacher.id}
+                        daysPerWeek={school?.daysPerWeek ?? 5}
+                        maxPeriodsPerDay={school?.maxPeriodsPerDay ?? 6}
+                        hasZeroPeriod={school?.hasZeroPeriod ?? false}
+                        availabilities={selectedTeacher.availabilities ?? []}
+                        onToggle={handleAvailabilityToggle}
+                      />
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+
+                <TabsContent value="subjects" className="mt-4">
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>持ち駒</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <TeacherKomaList teacherId={selectedTeacher.id} />
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+              </Tabs>
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <p className="text-muted-foreground">
+                左のリストから先生を選択してください
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>先生を追加</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>先生名</Label>
+              <Input
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
+                placeholder="例: 山田太郎"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>ふりがな</Label>
+              <Input
+                value={formNameKana}
+                onChange={(e) => setFormNameKana(e.target.value)}
+                placeholder="例: やまだたろう"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>週当たり最大コマ数</Label>
+              <Input
+                type="number"
+                min={1}
+                max={40}
+                value={formMaxPeriods}
+                onChange={(e) =>
+                  setFormMaxPeriods(parseInt(e.target.value) || 25)
+                }
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setDialogOpen(false)}>
+                キャンセル
+              </Button>
+              <Button onClick={handleCreateTeacher}>追加</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,15 @@
 "use client"
 
-import { BookOpen, Calendar, GraduationCap, School, Users } from "lucide-react"
+import {
+  BookOpen,
+  Briefcase,
+  Building2,
+  Calendar,
+  GraduationCap,
+  Puzzle,
+  School,
+  Users,
+} from "lucide-react"
 import Link from "next/link"
 
 import { Badge } from "@/components/ui/badge"
@@ -61,6 +70,30 @@ const navCards: NavCard[] = [
     icon: <GraduationCap className="h-6 w-6" />,
     section: "data",
     step: 5,
+  },
+  {
+    title: "特別教室",
+    description: "特別教室の情報と使用可能時間を設定します",
+    href: "/data/rooms",
+    icon: <Building2 className="h-6 w-6" />,
+    section: "data",
+    step: 6,
+  },
+  {
+    title: "校務",
+    description: "校務の情報と担当先生を設定します",
+    href: "/data/duties",
+    icon: <Briefcase className="h-6 w-6" />,
+    section: "data",
+    step: 7,
+  },
+  {
+    title: "駒設定",
+    description: "各学年の教科駒を設定・一括生成します",
+    href: "/data/koma",
+    icon: <Puzzle className="h-6 w-6" />,
+    section: "data",
+    step: 8,
   },
 ]
 

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -2,9 +2,12 @@
 
 import {
   BookOpen,
+  Briefcase,
+  Building2,
   Calendar,
   GraduationCap,
   LayoutDashboard,
+  Puzzle,
   School,
   Settings,
   Users,
@@ -50,6 +53,21 @@ const dataItems: NavItem[] = [
     label: "クラス設定",
     href: "/data/classes",
     icon: <GraduationCap className="h-4 w-4" />,
+  },
+  {
+    label: "特別教室",
+    href: "/data/rooms",
+    icon: <Building2 className="h-4 w-4" />,
+  },
+  {
+    label: "校務",
+    href: "/data/duties",
+    icon: <Briefcase className="h-4 w-4" />,
+  },
+  {
+    label: "駒設定",
+    href: "/data/koma",
+    icon: <Puzzle className="h-4 w-4" />,
   },
 ]
 

--- a/components/timetable/TeacherKomaList.tsx
+++ b/components/timetable/TeacherKomaList.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { KOMA_TEACHER_ROLES, KOMA_TYPES } from "@/lib/constants"
+import type { Koma } from "@/types/common.types"
+
+interface TeacherKomaListProps {
+  teacherId: string
+}
+
+export function TeacherKomaList({ teacherId }: TeacherKomaListProps) {
+  const [komas, setKomas] = useState<Koma[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchKomas = useCallback(async () => {
+    try {
+      setLoading(true)
+      const data = await window.electronAPI.komaGetByTeacherId(teacherId)
+      setKomas(data)
+    } catch {
+      console.error("Failed to fetch komas for teacher")
+    } finally {
+      setLoading(false)
+    }
+  }, [teacherId])
+
+  useEffect(() => {
+    fetchKomas()
+  }, [fetchKomas])
+
+  if (loading) {
+    return <p className="text-muted-foreground text-sm">読み込み中...</p>
+  }
+
+  if (komas.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        割り当てられた駒はありません
+      </p>
+    )
+  }
+
+  const totalCount = komas.reduce((sum, k) => sum + k.count, 0)
+
+  return (
+    <div className="space-y-2">
+      <div className="text-muted-foreground text-sm">
+        合計: {totalCount}コマ/週
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>学年</TableHead>
+            <TableHead>教科</TableHead>
+            <TableHead>種類</TableHead>
+            <TableHead className="text-center">駒数</TableHead>
+            <TableHead>役割</TableHead>
+            <TableHead>ラベル</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {komas.map((koma) => {
+            const role = koma.komaTeachers?.find(
+              (kt) => kt.teacherId === teacherId
+            )?.role
+            return (
+              <TableRow key={koma.id}>
+                <TableCell>{koma.grade?.name ?? "-"}</TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-1.5">
+                    {koma.subject && (
+                      <div
+                        className="h-2.5 w-2.5 rounded-full"
+                        style={{ backgroundColor: koma.subject.color }}
+                      />
+                    )}
+                    {koma.subject?.name ?? "-"}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline" className="text-xs">
+                    {KOMA_TYPES[koma.type as keyof typeof KOMA_TYPES] ?? koma.type}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-center">{koma.count}</TableCell>
+                <TableCell>
+                  {role
+                    ? KOMA_TEACHER_ROLES[
+                        role as keyof typeof KOMA_TEACHER_ROLES
+                      ]
+                    : "-"}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {koma.label || "-"}
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/electron-src/ipc-handlers/dutyHandlers.ts
+++ b/electron-src/ipc-handlers/dutyHandlers.ts
@@ -1,0 +1,33 @@
+import { ipcMain } from "electron"
+
+import * as dutyDAL from "../lib/prisma/duty"
+import * as teacherDutyDAL from "../lib/prisma/teacherDuty"
+
+export function registerDutyHandlers() {
+  ipcMain.handle("duty:getAll", async () => {
+    return await dutyDAL.getDuties()
+  })
+
+  ipcMain.handle("duty:getById", async (_event, id: string) => {
+    return await dutyDAL.getDutyById(id)
+  })
+
+  ipcMain.handle("duty:create", async (_event, data) => {
+    return await dutyDAL.createDuty(data)
+  })
+
+  ipcMain.handle("duty:update", async (_event, id: string, data) => {
+    return await dutyDAL.updateDuty(id, data)
+  })
+
+  ipcMain.handle("duty:delete", async (_event, id: string) => {
+    return await dutyDAL.deleteDuty(id)
+  })
+
+  ipcMain.handle(
+    "duty:setTeachers",
+    async (_event, dutyId: string, teacherIds: string[]) => {
+      return await teacherDutyDAL.batchSetTeachersForDuty(dutyId, teacherIds)
+    }
+  )
+}

--- a/electron-src/ipc-handlers/index.ts
+++ b/electron-src/ipc-handlers/index.ts
@@ -1,6 +1,9 @@
 import { registerClassHandlers } from "./classHandlers"
+import { registerDutyHandlers } from "./dutyHandlers"
 import { registerGradeHandlers } from "./gradeHandlers"
+import { registerKomaHandlers } from "./komaHandlers"
 import { registerMiscHandlers } from "./miscHandlers"
+import { registerRoomHandlers } from "./roomHandlers"
 import { registerSchoolHandlers } from "./schoolHandlers"
 import { registerSubjectHandlers } from "./subjectHandlers"
 import { registerTeacherHandlers } from "./teacherHandlers"
@@ -11,6 +14,9 @@ export function setupAllIPCHandlers() {
   registerClassHandlers()
   registerTeacherHandlers()
   registerSubjectHandlers()
+  registerRoomHandlers()
+  registerDutyHandlers()
+  registerKomaHandlers()
   registerMiscHandlers()
 
   console.log("All IPC handlers registered successfully")

--- a/electron-src/ipc-handlers/komaHandlers.ts
+++ b/electron-src/ipc-handlers/komaHandlers.ts
@@ -1,0 +1,76 @@
+import { ipcMain } from "electron"
+
+import * as komaDAL from "../lib/prisma/koma"
+
+export function registerKomaHandlers() {
+  ipcMain.handle("koma:getAll", async () => {
+    return await komaDAL.getKomas()
+  })
+
+  ipcMain.handle("koma:getById", async (_event, id: string) => {
+    return await komaDAL.getKomaById(id)
+  })
+
+  ipcMain.handle("koma:getByGradeId", async (_event, gradeId: string) => {
+    return await komaDAL.getKomasByGradeId(gradeId)
+  })
+
+  ipcMain.handle("koma:create", async (_event, data) => {
+    return await komaDAL.createKoma(data)
+  })
+
+  ipcMain.handle("koma:update", async (_event, id: string, data) => {
+    return await komaDAL.updateKoma(id, data)
+  })
+
+  ipcMain.handle("koma:delete", async (_event, id: string) => {
+    return await komaDAL.deleteKoma(id)
+  })
+
+  ipcMain.handle("koma:duplicate", async (_event, id: string) => {
+    return await komaDAL.duplicateKoma(id)
+  })
+
+  ipcMain.handle(
+    "koma:setTeachers",
+    async (
+      _event,
+      komaId: string,
+      teachers: { teacherId: string; role: string }[]
+    ) => {
+      return await komaDAL.setKomaTeachers(komaId, teachers)
+    }
+  )
+
+  ipcMain.handle(
+    "koma:setClasses",
+    async (_event, komaId: string, classIds: string[]) => {
+      return await komaDAL.setKomaClasses(komaId, classIds)
+    }
+  )
+
+  ipcMain.handle(
+    "koma:setRooms",
+    async (_event, komaId: string, roomIds: string[]) => {
+      return await komaDAL.setKomaRooms(komaId, roomIds)
+    }
+  )
+
+  ipcMain.handle("koma:batchCreate", async (_event, komas) => {
+    return await komaDAL.batchCreateKomas(komas)
+  })
+
+  ipcMain.handle(
+    "koma:getByTeacherId",
+    async (_event, teacherId: string) => {
+      return await komaDAL.getKomasByTeacherId(teacherId)
+    }
+  )
+
+  ipcMain.handle(
+    "koma:deleteByGradeId",
+    async (_event, gradeId: string) => {
+      return await komaDAL.deleteKomasByGradeId(gradeId)
+    }
+  )
+}

--- a/electron-src/ipc-handlers/roomHandlers.ts
+++ b/electron-src/ipc-handlers/roomHandlers.ts
@@ -1,0 +1,49 @@
+import { ipcMain } from "electron"
+
+import * as roomDAL from "../lib/prisma/room"
+import * as roomAvailabilityDAL from "../lib/prisma/roomAvailability"
+
+export function registerRoomHandlers() {
+  ipcMain.handle("room:getAll", async () => {
+    return await roomDAL.getRooms()
+  })
+
+  ipcMain.handle("room:getById", async (_event, id: string) => {
+    return await roomDAL.getRoomById(id)
+  })
+
+  ipcMain.handle("room:create", async (_event, data) => {
+    return await roomDAL.createRoom(data)
+  })
+
+  ipcMain.handle("room:update", async (_event, id: string, data) => {
+    return await roomDAL.updateRoom(id, data)
+  })
+
+  ipcMain.handle("room:delete", async (_event, id: string) => {
+    return await roomDAL.deleteRoom(id)
+  })
+
+  ipcMain.handle(
+    "room:getWithAvailabilities",
+    async (_event, id: string) => {
+      return await roomDAL.getRoomWithAvailabilities(id)
+    }
+  )
+
+  // RoomAvailability
+  ipcMain.handle("roomAvailability:upsert", async (_event, data) => {
+    return await roomAvailabilityDAL.upsertRoomAvailability(data)
+  })
+
+  ipcMain.handle("roomAvailability:batchUpsert", async (_event, items) => {
+    return await roomAvailabilityDAL.batchUpsertRoomAvailabilities(items)
+  })
+
+  ipcMain.handle(
+    "roomAvailability:getByRoomId",
+    async (_event, roomId: string) => {
+      return await roomAvailabilityDAL.getRoomAvailabilities(roomId)
+    }
+  )
+}

--- a/electron-src/lib/databaseSetup.ts
+++ b/electron-src/lib/databaseSetup.ts
@@ -195,6 +195,11 @@ export class DatabaseSetup {
           setupPerformed = true
         }
       } else {
+        // 既存DBのアップグレード (Phase 2 テーブル追加)
+        const { upgradeDatabase } =
+          await import("./prisma/databaseInitializer")
+        await upgradeDatabase()
+
         const isEmpty = await this.isDatabaseEmpty()
         if (isEmpty) {
           await this.runSeed()

--- a/electron-src/lib/prisma/databaseInitializer.ts
+++ b/electron-src/lib/prisma/databaseInitializer.ts
@@ -83,6 +83,8 @@ CREATE TABLE "Teacher" (
     "name" TEXT NOT NULL,
     "nameKana" TEXT NOT NULL DEFAULT '',
     "mainSubjectId" TEXT,
+    "maxConsecutive" INTEGER NOT NULL DEFAULT 6,
+    "maxPerDay" INTEGER NOT NULL DEFAULT 6,
     "maxPeriodsPerWeek" INTEGER NOT NULL DEFAULT 25,
     "notes" TEXT NOT NULL DEFAULT '',
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -113,6 +115,96 @@ CREATE TABLE "Subject" (
 );
         `
 
+        const phase2SQL = `
+CREATE TABLE "SpecialRoom" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "shortName" TEXT NOT NULL DEFAULT '',
+    "capacity" INTEGER NOT NULL DEFAULT 40,
+    "notes" TEXT NOT NULL DEFAULT '',
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+CREATE TABLE "RoomAvailability" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "roomId" TEXT NOT NULL,
+    "dayOfWeek" INTEGER NOT NULL,
+    "period" INTEGER NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'available',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "RoomAvailability_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "SpecialRoom" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "Duty" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "shortName" TEXT NOT NULL DEFAULT '',
+    "dayOfWeek" INTEGER NOT NULL,
+    "period" INTEGER NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+CREATE TABLE "TeacherDuty" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "dutyId" TEXT NOT NULL,
+    "teacherId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "TeacherDuty_dutyId_fkey" FOREIGN KEY ("dutyId") REFERENCES "Duty" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "TeacherDuty_teacherId_fkey" FOREIGN KEY ("teacherId") REFERENCES "Teacher" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "Koma" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "subjectId" TEXT NOT NULL,
+    "gradeId" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'normal',
+    "count" INTEGER NOT NULL DEFAULT 1,
+    "priority" INTEGER NOT NULL DEFAULT 5,
+    "label" TEXT NOT NULL DEFAULT '',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Koma_subjectId_fkey" FOREIGN KEY ("subjectId") REFERENCES "Subject" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Koma_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "KomaTeacher" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "komaId" TEXT NOT NULL,
+    "teacherId" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'main',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "KomaTeacher_komaId_fkey" FOREIGN KEY ("komaId") REFERENCES "Koma" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "KomaTeacher_teacherId_fkey" FOREIGN KEY ("teacherId") REFERENCES "Teacher" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "KomaClass" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "komaId" TEXT NOT NULL,
+    "classId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "KomaClass_komaId_fkey" FOREIGN KEY ("komaId") REFERENCES "Koma" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "KomaClass_classId_fkey" FOREIGN KEY ("classId") REFERENCES "Class" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "KomaRoom" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "komaId" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "KomaRoom_komaId_fkey" FOREIGN KEY ("komaId") REFERENCES "Koma" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "KomaRoom_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "SpecialRoom" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+        `
+
         const indexSQL = `
 CREATE UNIQUE INDEX "Grade_gradeNum_key" ON "Grade"("gradeNum");
 CREATE UNIQUE INDEX "Class_gradeId_name_key" ON "Class"("gradeId", "name");
@@ -120,9 +212,25 @@ CREATE INDEX "Class_gradeId_idx" ON "Class"("gradeId");
 CREATE UNIQUE INDEX "TeacherAvailability_teacherId_dayOfWeek_period_key" ON "TeacherAvailability"("teacherId", "dayOfWeek", "period");
 CREATE INDEX "TeacherAvailability_teacherId_idx" ON "TeacherAvailability"("teacherId");
 CREATE UNIQUE INDEX "Subject_name_key" ON "Subject"("name");
+CREATE UNIQUE INDEX "RoomAvailability_roomId_dayOfWeek_period_key" ON "RoomAvailability"("roomId", "dayOfWeek", "period");
+CREATE INDEX "RoomAvailability_roomId_idx" ON "RoomAvailability"("roomId");
+CREATE UNIQUE INDEX "TeacherDuty_dutyId_teacherId_key" ON "TeacherDuty"("dutyId", "teacherId");
+CREATE INDEX "TeacherDuty_dutyId_idx" ON "TeacherDuty"("dutyId");
+CREATE INDEX "TeacherDuty_teacherId_idx" ON "TeacherDuty"("teacherId");
+CREATE INDEX "Koma_subjectId_idx" ON "Koma"("subjectId");
+CREATE INDEX "Koma_gradeId_idx" ON "Koma"("gradeId");
+CREATE UNIQUE INDEX "KomaTeacher_komaId_teacherId_key" ON "KomaTeacher"("komaId", "teacherId");
+CREATE INDEX "KomaTeacher_komaId_idx" ON "KomaTeacher"("komaId");
+CREATE INDEX "KomaTeacher_teacherId_idx" ON "KomaTeacher"("teacherId");
+CREATE UNIQUE INDEX "KomaClass_komaId_classId_key" ON "KomaClass"("komaId", "classId");
+CREATE INDEX "KomaClass_komaId_idx" ON "KomaClass"("komaId");
+CREATE INDEX "KomaClass_classId_idx" ON "KomaClass"("classId");
+CREATE UNIQUE INDEX "KomaRoom_komaId_roomId_key" ON "KomaRoom"("komaId", "roomId");
+CREATE INDEX "KomaRoom_komaId_idx" ON "KomaRoom"("komaId");
+CREATE INDEX "KomaRoom_roomId_idx" ON "KomaRoom"("roomId");
         `
 
-        const allSQL = migrationSQL + indexSQL
+        const allSQL = migrationSQL + phase2SQL + indexSQL
         const statements = allSQL.split(";").filter((stmt) => stmt.trim())
 
         for (const statement of statements) {
@@ -149,6 +257,162 @@ CREATE UNIQUE INDEX "Subject_name_key" ON "Subject"("name");
   } catch (error) {
     console.error("Database initialization failed:", error)
     throw error
+  }
+}
+
+export const upgradeDatabase = async (): Promise<void> => {
+  const prisma = createSharedPrismaClient()
+  try {
+    await prisma.$connect()
+
+    // Phase 2 テーブルが存在するかチェック
+    const tables = await prisma.$queryRawUnsafe<{ name: string }[]>(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='SpecialRoom'`
+    )
+
+    if (tables.length > 0) {
+      // Phase 2 テーブルは存在するが、Teacher に新カラムがあるかチェック
+      try {
+        await prisma.$queryRawUnsafe(
+          `SELECT "maxConsecutive" FROM "Teacher" LIMIT 1`
+        )
+      } catch {
+        // カラムが存在しない場合は追加
+        await prisma.$executeRawUnsafe(
+          `ALTER TABLE "Teacher" ADD COLUMN "maxConsecutive" INTEGER NOT NULL DEFAULT 6`
+        )
+        await prisma.$executeRawUnsafe(
+          `ALTER TABLE "Teacher" ADD COLUMN "maxPerDay" INTEGER NOT NULL DEFAULT 6`
+        )
+        console.log("Added maxConsecutive and maxPerDay columns to Teacher")
+      }
+      return
+    }
+
+    const phase2SQL = `
+CREATE TABLE "SpecialRoom" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "shortName" TEXT NOT NULL DEFAULT '',
+    "capacity" INTEGER NOT NULL DEFAULT 40,
+    "notes" TEXT NOT NULL DEFAULT '',
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+CREATE TABLE "RoomAvailability" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "roomId" TEXT NOT NULL,
+    "dayOfWeek" INTEGER NOT NULL,
+    "period" INTEGER NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'available',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "RoomAvailability_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "SpecialRoom" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "Duty" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "shortName" TEXT NOT NULL DEFAULT '',
+    "dayOfWeek" INTEGER NOT NULL,
+    "period" INTEGER NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+CREATE TABLE "TeacherDuty" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "dutyId" TEXT NOT NULL,
+    "teacherId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "TeacherDuty_dutyId_fkey" FOREIGN KEY ("dutyId") REFERENCES "Duty" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "TeacherDuty_teacherId_fkey" FOREIGN KEY ("teacherId") REFERENCES "Teacher" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "Koma" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "subjectId" TEXT NOT NULL,
+    "gradeId" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'normal',
+    "count" INTEGER NOT NULL DEFAULT 1,
+    "priority" INTEGER NOT NULL DEFAULT 5,
+    "label" TEXT NOT NULL DEFAULT '',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Koma_subjectId_fkey" FOREIGN KEY ("subjectId") REFERENCES "Subject" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Koma_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "KomaTeacher" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "komaId" TEXT NOT NULL,
+    "teacherId" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'main',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "KomaTeacher_komaId_fkey" FOREIGN KEY ("komaId") REFERENCES "Koma" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "KomaTeacher_teacherId_fkey" FOREIGN KEY ("teacherId") REFERENCES "Teacher" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "KomaClass" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "komaId" TEXT NOT NULL,
+    "classId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "KomaClass_komaId_fkey" FOREIGN KEY ("komaId") REFERENCES "Koma" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "KomaClass_classId_fkey" FOREIGN KEY ("classId") REFERENCES "Class" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "KomaRoom" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "komaId" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "KomaRoom_komaId_fkey" FOREIGN KEY ("komaId") REFERENCES "Koma" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "KomaRoom_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "SpecialRoom" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+    `
+
+    const phase2IndexSQL = `
+CREATE UNIQUE INDEX "RoomAvailability_roomId_dayOfWeek_period_key" ON "RoomAvailability"("roomId", "dayOfWeek", "period");
+CREATE INDEX "RoomAvailability_roomId_idx" ON "RoomAvailability"("roomId");
+CREATE UNIQUE INDEX "TeacherDuty_dutyId_teacherId_key" ON "TeacherDuty"("dutyId", "teacherId");
+CREATE INDEX "TeacherDuty_dutyId_idx" ON "TeacherDuty"("dutyId");
+CREATE INDEX "TeacherDuty_teacherId_idx" ON "TeacherDuty"("teacherId");
+CREATE INDEX "Koma_subjectId_idx" ON "Koma"("subjectId");
+CREATE INDEX "Koma_gradeId_idx" ON "Koma"("gradeId");
+CREATE UNIQUE INDEX "KomaTeacher_komaId_teacherId_key" ON "KomaTeacher"("komaId", "teacherId");
+CREATE INDEX "KomaTeacher_komaId_idx" ON "KomaTeacher"("komaId");
+CREATE INDEX "KomaTeacher_teacherId_idx" ON "KomaTeacher"("teacherId");
+CREATE UNIQUE INDEX "KomaClass_komaId_classId_key" ON "KomaClass"("komaId", "classId");
+CREATE INDEX "KomaClass_komaId_idx" ON "KomaClass"("komaId");
+CREATE INDEX "KomaClass_classId_idx" ON "KomaClass"("classId");
+CREATE UNIQUE INDEX "KomaRoom_komaId_roomId_key" ON "KomaRoom"("komaId", "roomId");
+CREATE INDEX "KomaRoom_komaId_idx" ON "KomaRoom"("komaId");
+CREATE INDEX "KomaRoom_roomId_idx" ON "KomaRoom"("roomId");
+    `
+
+    const allSQL = phase2SQL + phase2IndexSQL
+    const statements = allSQL.split(";").filter((stmt) => stmt.trim())
+
+    for (const statement of statements) {
+      if (statement.trim()) {
+        await prisma.$executeRawUnsafe(statement.trim())
+      }
+    }
+
+    console.log("Database upgraded to Phase 2 successfully")
+  } catch (error) {
+    console.error("Failed to upgrade database:", error)
+    throw error
+  } finally {
+    await prisma.$disconnect()
   }
 }
 

--- a/electron-src/lib/prisma/duty.ts
+++ b/electron-src/lib/prisma/duty.ts
@@ -1,0 +1,75 @@
+import { getPrismaClient } from "./client"
+
+export async function getDuties() {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.duty.findMany({
+      include: {
+        teacherDuties: {
+          include: { teacher: true },
+        },
+      },
+      orderBy: { sortOrder: "asc" },
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function getDutyById(id: string) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.duty.findUnique({
+      where: { id },
+      include: {
+        teacherDuties: {
+          include: { teacher: true },
+        },
+      },
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function createDuty(data: {
+  name: string
+  shortName?: string
+  dayOfWeek: number
+  period: number
+  sortOrder?: number
+}) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.duty.create({ data })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function updateDuty(
+  id: string,
+  data: {
+    name?: string
+    shortName?: string
+    dayOfWeek?: number
+    period?: number
+    sortOrder?: number
+  }
+) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.duty.update({ where: { id }, data })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function deleteDuty(id: string) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.duty.delete({ where: { id } })
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/electron-src/lib/prisma/koma.ts
+++ b/electron-src/lib/prisma/koma.ts
@@ -1,0 +1,262 @@
+import { getPrismaClient } from "./client"
+
+const komaIncludes = {
+  subject: true,
+  grade: true,
+  komaTeachers: { include: { teacher: true } },
+  komaClasses: { include: { class_: true } },
+  komaRooms: { include: { room: true } },
+}
+
+export async function getKomas() {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.koma.findMany({
+      include: komaIncludes,
+      orderBy: [{ gradeId: "asc" }, { subjectId: "asc" }],
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function getKomaById(id: string) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.koma.findUnique({
+      where: { id },
+      include: komaIncludes,
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function getKomasByGradeId(gradeId: string) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.koma.findMany({
+      where: { gradeId },
+      include: komaIncludes,
+      orderBy: [{ subject: { sortOrder: "asc" } }, { label: "asc" }],
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function createKoma(data: {
+  subjectId: string
+  gradeId: string
+  type?: string
+  count?: number
+  priority?: number
+  label?: string
+}) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.koma.create({
+      data,
+      include: komaIncludes,
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function updateKoma(
+  id: string,
+  data: {
+    subjectId?: string
+    type?: string
+    count?: number
+    priority?: number
+    label?: string
+  }
+) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.koma.update({
+      where: { id },
+      data,
+      include: komaIncludes,
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function deleteKoma(id: string) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.koma.delete({ where: { id } })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function duplicateKoma(id: string) {
+  const prisma = getPrismaClient()
+  try {
+    const original = await prisma.koma.findUnique({
+      where: { id },
+      include: {
+        komaTeachers: true,
+        komaClasses: true,
+        komaRooms: true,
+      },
+    })
+    if (!original) throw new Error("Koma not found")
+
+    return await prisma.$transaction(async (tx) => {
+      const newKoma = await tx.koma.create({
+        data: {
+          subjectId: original.subjectId,
+          gradeId: original.gradeId,
+          type: original.type,
+          count: original.count,
+          priority: original.priority,
+          label: original.label ? `${original.label} (コピー)` : "(コピー)",
+        },
+      })
+
+      if (original.komaTeachers.length > 0) {
+        await tx.komaTeacher.createMany({
+          data: original.komaTeachers.map((kt) => ({
+            komaId: newKoma.id,
+            teacherId: kt.teacherId,
+            role: kt.role,
+          })),
+        })
+      }
+
+      if (original.komaClasses.length > 0) {
+        await tx.komaClass.createMany({
+          data: original.komaClasses.map((kc) => ({
+            komaId: newKoma.id,
+            classId: kc.classId,
+          })),
+        })
+      }
+
+      if (original.komaRooms.length > 0) {
+        await tx.komaRoom.createMany({
+          data: original.komaRooms.map((kr) => ({
+            komaId: newKoma.id,
+            roomId: kr.roomId,
+          })),
+        })
+      }
+
+      return await tx.koma.findUnique({
+        where: { id: newKoma.id },
+        include: komaIncludes,
+      })
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function setKomaTeachers(
+  komaId: string,
+  teachers: { teacherId: string; role: string }[]
+) {
+  const prisma = getPrismaClient()
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.komaTeacher.deleteMany({ where: { komaId } })
+      if (teachers.length > 0) {
+        await tx.komaTeacher.createMany({
+          data: teachers.map((t) => ({
+            komaId,
+            teacherId: t.teacherId,
+            role: t.role,
+          })),
+        })
+      }
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function setKomaClasses(komaId: string, classIds: string[]) {
+  const prisma = getPrismaClient()
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.komaClass.deleteMany({ where: { komaId } })
+      if (classIds.length > 0) {
+        await tx.komaClass.createMany({
+          data: classIds.map((classId) => ({ komaId, classId })),
+        })
+      }
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function setKomaRooms(komaId: string, roomIds: string[]) {
+  const prisma = getPrismaClient()
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.komaRoom.deleteMany({ where: { komaId } })
+      if (roomIds.length > 0) {
+        await tx.komaRoom.createMany({
+          data: roomIds.map((roomId) => ({ komaId, roomId })),
+        })
+      }
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function batchCreateKomas(
+  komas: {
+    subjectId: string
+    gradeId: string
+    type?: string
+    count?: number
+    priority?: number
+    label?: string
+  }[]
+) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.$transaction(
+      komas.map((k) =>
+        prisma.koma.create({ data: k, include: komaIncludes })
+      )
+    )
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function getKomasByTeacherId(teacherId: string) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.koma.findMany({
+      where: {
+        komaTeachers: {
+          some: { teacherId },
+        },
+      },
+      include: komaIncludes,
+      orderBy: [{ grade: { gradeNum: "asc" } }, { subject: { sortOrder: "asc" } }],
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function deleteKomasByGradeId(gradeId: string) {
+  const prisma = getPrismaClient()
+  try {
+    await prisma.koma.deleteMany({ where: { gradeId } })
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/electron-src/lib/prisma/room.ts
+++ b/electron-src/lib/prisma/room.ts
@@ -1,0 +1,83 @@
+import { getPrismaClient } from "./client"
+
+export async function getRooms() {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.specialRoom.findMany({
+      include: { availabilities: true },
+      orderBy: { sortOrder: "asc" },
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function getRoomById(id: string) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.specialRoom.findUnique({
+      where: { id },
+      include: { availabilities: true },
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function createRoom(data: {
+  name: string
+  shortName?: string
+  capacity?: number
+  notes?: string
+  sortOrder?: number
+}) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.specialRoom.create({ data })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function updateRoom(
+  id: string,
+  data: {
+    name?: string
+    shortName?: string
+    capacity?: number
+    notes?: string
+    sortOrder?: number
+  }
+) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.specialRoom.update({ where: { id }, data })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function deleteRoom(id: string) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.specialRoom.delete({ where: { id } })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function getRoomWithAvailabilities(id: string) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.specialRoom.findUnique({
+      where: { id },
+      include: {
+        availabilities: {
+          orderBy: [{ dayOfWeek: "asc" }, { period: "asc" }],
+        },
+      },
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/electron-src/lib/prisma/roomAvailability.ts
+++ b/electron-src/lib/prisma/roomAvailability.ts
@@ -1,0 +1,67 @@
+import { getPrismaClient } from "./client"
+
+export async function upsertRoomAvailability(data: {
+  roomId: string
+  dayOfWeek: number
+  period: number
+  status: string
+}) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.roomAvailability.upsert({
+      where: {
+        roomId_dayOfWeek_period: {
+          roomId: data.roomId,
+          dayOfWeek: data.dayOfWeek,
+          period: data.period,
+        },
+      },
+      update: { status: data.status },
+      create: data,
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function batchUpsertRoomAvailabilities(
+  items: {
+    roomId: string
+    dayOfWeek: number
+    period: number
+    status: string
+  }[]
+) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.$transaction(
+      items.map((item) =>
+        prisma.roomAvailability.upsert({
+          where: {
+            roomId_dayOfWeek_period: {
+              roomId: item.roomId,
+              dayOfWeek: item.dayOfWeek,
+              period: item.period,
+            },
+          },
+          update: { status: item.status },
+          create: item,
+        })
+      )
+    )
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+export async function getRoomAvailabilities(roomId: string) {
+  const prisma = getPrismaClient()
+  try {
+    return await prisma.roomAvailability.findMany({
+      where: { roomId },
+      orderBy: [{ dayOfWeek: "asc" }, { period: "asc" }],
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/electron-src/lib/prisma/teacher.ts
+++ b/electron-src/lib/prisma/teacher.ts
@@ -4,7 +4,10 @@ export async function getTeachers() {
   const prisma = getPrismaClient()
   try {
     return await prisma.teacher.findMany({
-      include: { availabilities: true },
+      include: {
+        availabilities: true,
+        teacherDuties: { include: { duty: true } },
+      },
       orderBy: { name: "asc" },
     })
   } finally {
@@ -28,6 +31,8 @@ export async function createTeacher(data: {
   name: string
   nameKana?: string
   mainSubjectId?: string
+  maxConsecutive?: number
+  maxPerDay?: number
   maxPeriodsPerWeek?: number
   notes?: string
 }) {
@@ -45,6 +50,8 @@ export async function updateTeacher(
     name?: string
     nameKana?: string
     mainSubjectId?: string | null
+    maxConsecutive?: number
+    maxPerDay?: number
     maxPeriodsPerWeek?: number
     notes?: string
   }

--- a/electron-src/lib/prisma/teacherDuty.ts
+++ b/electron-src/lib/prisma/teacherDuty.ts
@@ -1,0 +1,26 @@
+import { getPrismaClient } from "./client"
+
+export async function batchSetTeachersForDuty(
+  dutyId: string,
+  teacherIds: string[]
+) {
+  const prisma = getPrismaClient()
+  try {
+    await prisma.$transaction(async (tx) => {
+      // 既存の割当を全削除
+      await tx.teacherDuty.deleteMany({ where: { dutyId } })
+
+      // 新しい割当を作成
+      if (teacherIds.length > 0) {
+        await tx.teacherDuty.createMany({
+          data: teacherIds.map((teacherId) => ({
+            dutyId,
+            teacherId,
+          })),
+        })
+      }
+    })
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -83,6 +83,72 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("subject:getByCategory", category),
   subjectSeedDefaults: () => ipcRenderer.invoke("subject:seedDefaults"),
 
+  // SpecialRoom
+  roomGetAll: () => ipcRenderer.invoke("room:getAll"),
+  roomGetById: (id: string) => ipcRenderer.invoke("room:getById", id),
+  roomCreate: (data: Record<string, unknown>) =>
+    ipcRenderer.invoke("room:create", data),
+  roomUpdate: (id: string, data: Record<string, unknown>) =>
+    ipcRenderer.invoke("room:update", id, data),
+  roomDelete: (id: string) => ipcRenderer.invoke("room:delete", id),
+  roomGetWithAvailabilities: (id: string) =>
+    ipcRenderer.invoke("room:getWithAvailabilities", id),
+
+  // RoomAvailability
+  roomAvailabilityUpsert: (data: {
+    roomId: string
+    dayOfWeek: number
+    period: number
+    status: string
+  }) => ipcRenderer.invoke("roomAvailability:upsert", data),
+  roomAvailabilityBatchUpsert: (
+    items: {
+      roomId: string
+      dayOfWeek: number
+      period: number
+      status: string
+    }[]
+  ) => ipcRenderer.invoke("roomAvailability:batchUpsert", items),
+  roomAvailabilityGetByRoomId: (roomId: string) =>
+    ipcRenderer.invoke("roomAvailability:getByRoomId", roomId),
+
+  // Duty
+  dutyGetAll: () => ipcRenderer.invoke("duty:getAll"),
+  dutyGetById: (id: string) => ipcRenderer.invoke("duty:getById", id),
+  dutyCreate: (data: Record<string, unknown>) =>
+    ipcRenderer.invoke("duty:create", data),
+  dutyUpdate: (id: string, data: Record<string, unknown>) =>
+    ipcRenderer.invoke("duty:update", id, data),
+  dutyDelete: (id: string) => ipcRenderer.invoke("duty:delete", id),
+  dutySetTeachers: (dutyId: string, teacherIds: string[]) =>
+    ipcRenderer.invoke("duty:setTeachers", dutyId, teacherIds),
+
+  // Koma
+  komaGetAll: () => ipcRenderer.invoke("koma:getAll"),
+  komaGetById: (id: string) => ipcRenderer.invoke("koma:getById", id),
+  komaGetByGradeId: (gradeId: string) =>
+    ipcRenderer.invoke("koma:getByGradeId", gradeId),
+  komaCreate: (data: Record<string, unknown>) =>
+    ipcRenderer.invoke("koma:create", data),
+  komaUpdate: (id: string, data: Record<string, unknown>) =>
+    ipcRenderer.invoke("koma:update", id, data),
+  komaDelete: (id: string) => ipcRenderer.invoke("koma:delete", id),
+  komaDuplicate: (id: string) => ipcRenderer.invoke("koma:duplicate", id),
+  komaSetTeachers: (
+    komaId: string,
+    teachers: { teacherId: string; role: string }[]
+  ) => ipcRenderer.invoke("koma:setTeachers", komaId, teachers),
+  komaSetClasses: (komaId: string, classIds: string[]) =>
+    ipcRenderer.invoke("koma:setClasses", komaId, classIds),
+  komaSetRooms: (komaId: string, roomIds: string[]) =>
+    ipcRenderer.invoke("koma:setRooms", komaId, roomIds),
+  komaBatchCreate: (komas: Record<string, unknown>[]) =>
+    ipcRenderer.invoke("koma:batchCreate", komas),
+  komaGetByTeacherId: (teacherId: string) =>
+    ipcRenderer.invoke("koma:getByTeacherId", teacherId),
+  komaDeleteByGradeId: (gradeId: string) =>
+    ipcRenderer.invoke("koma:deleteByGradeId", gradeId),
+
   // Misc
   getAppVersion: () => ipcRenderer.invoke("misc:getAppVersion"),
   getDataDirectoryInfo: () => ipcRenderer.invoke("misc:getDataDirectoryInfo"),

--- a/hooks/useDuties.ts
+++ b/hooks/useDuties.ts
@@ -1,0 +1,109 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import type { Duty } from "@/types/common.types"
+
+export function useDuties() {
+  const [duties, setDuties] = useState<Duty[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchDuties = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await window.electronAPI.dutyGetAll()
+      setDuties(data)
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "校務一覧の取得に失敗しました"
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const createDuty = useCallback(
+    async (data: Record<string, unknown>) => {
+      try {
+        setError(null)
+        const created = await window.electronAPI.dutyCreate(data)
+        await fetchDuties()
+        return created
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "校務の追加に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchDuties]
+  )
+
+  const updateDuty = useCallback(
+    async (id: string, data: Record<string, unknown>) => {
+      try {
+        setError(null)
+        const updated = await window.electronAPI.dutyUpdate(id, data)
+        await fetchDuties()
+        return updated
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "校務の更新に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchDuties]
+  )
+
+  const deleteDuty = useCallback(
+    async (id: string) => {
+      try {
+        setError(null)
+        await window.electronAPI.dutyDelete(id)
+        await fetchDuties()
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "校務の削除に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchDuties]
+  )
+
+  const setTeachersForDuty = useCallback(
+    async (dutyId: string, teacherIds: string[]) => {
+      try {
+        setError(null)
+        await window.electronAPI.dutySetTeachers(dutyId, teacherIds)
+        await fetchDuties()
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "担当先生の設定に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchDuties]
+  )
+
+  useEffect(() => {
+    fetchDuties()
+  }, [fetchDuties])
+
+  return {
+    duties,
+    loading,
+    error,
+    fetchDuties,
+    createDuty,
+    updateDuty,
+    deleteDuty,
+    setTeachersForDuty,
+  }
+}

--- a/hooks/useKomas.ts
+++ b/hooks/useKomas.ts
@@ -1,0 +1,209 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import type { Koma } from "@/types/common.types"
+
+export function useKomas(gradeId?: string) {
+  const [komas, setKomas] = useState<Koma[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchKomas = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = gradeId
+        ? await window.electronAPI.komaGetByGradeId(gradeId)
+        : await window.electronAPI.komaGetAll()
+      setKomas(data)
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "駒一覧の取得に失敗しました"
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [gradeId])
+
+  const createKoma = useCallback(
+    async (data: Record<string, unknown>) => {
+      try {
+        setError(null)
+        const created = await window.electronAPI.komaCreate(data)
+        await fetchKomas()
+        return created
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "駒の追加に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchKomas]
+  )
+
+  const updateKoma = useCallback(
+    async (id: string, data: Record<string, unknown>) => {
+      try {
+        setError(null)
+        const updated = await window.electronAPI.komaUpdate(id, data)
+        await fetchKomas()
+        return updated
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "駒の更新に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchKomas]
+  )
+
+  const deleteKoma = useCallback(
+    async (id: string) => {
+      try {
+        setError(null)
+        await window.electronAPI.komaDelete(id)
+        await fetchKomas()
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "駒の削除に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchKomas]
+  )
+
+  const duplicateKoma = useCallback(
+    async (id: string) => {
+      try {
+        setError(null)
+        const duplicated = await window.electronAPI.komaDuplicate(id)
+        await fetchKomas()
+        return duplicated
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "駒のコピーに失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchKomas]
+  )
+
+  const setKomaTeachers = useCallback(
+    async (
+      komaId: string,
+      teachers: { teacherId: string; role: string }[]
+    ) => {
+      try {
+        setError(null)
+        await window.electronAPI.komaSetTeachers(komaId, teachers)
+        await fetchKomas()
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "先生の設定に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchKomas]
+  )
+
+  const setKomaClasses = useCallback(
+    async (komaId: string, classIds: string[]) => {
+      try {
+        setError(null)
+        await window.electronAPI.komaSetClasses(komaId, classIds)
+        await fetchKomas()
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "クラスの設定に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchKomas]
+  )
+
+  const setKomaRooms = useCallback(
+    async (komaId: string, roomIds: string[]) => {
+      try {
+        setError(null)
+        await window.electronAPI.komaSetRooms(komaId, roomIds)
+        await fetchKomas()
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "教室の設定に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchKomas]
+  )
+
+  const batchCreateKomas = useCallback(
+    async (komasData: Record<string, unknown>[]) => {
+      try {
+        setError(null)
+        const created = await window.electronAPI.komaBatchCreate(komasData)
+        await fetchKomas()
+        return created
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "駒の一括作成に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchKomas]
+  )
+
+  const deleteKomasByGrade = useCallback(
+    async (targetGradeId: string) => {
+      try {
+        setError(null)
+        await window.electronAPI.komaDeleteByGradeId(targetGradeId)
+        await fetchKomas()
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "駒の一括削除に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchKomas]
+  )
+
+  useEffect(() => {
+    fetchKomas()
+  }, [fetchKomas])
+
+  return {
+    komas,
+    loading,
+    error,
+    fetchKomas,
+    createKoma,
+    updateKoma,
+    deleteKoma,
+    duplicateKoma,
+    setKomaTeachers,
+    setKomaClasses,
+    setKomaRooms,
+    batchCreateKomas,
+    deleteKomasByGrade,
+  }
+}

--- a/hooks/useRooms.ts
+++ b/hooks/useRooms.ts
@@ -1,0 +1,111 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import type { SpecialRoom } from "@/types/common.types"
+
+export function useRooms() {
+  const [rooms, setRooms] = useState<SpecialRoom[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchRooms = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await window.electronAPI.roomGetAll()
+      setRooms(data)
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "特別教室一覧の取得に失敗しました"
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const createRoom = useCallback(
+    async (data: Record<string, unknown>) => {
+      try {
+        setError(null)
+        const created = await window.electronAPI.roomCreate(data)
+        await fetchRooms()
+        return created
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "特別教室の追加に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchRooms]
+  )
+
+  const updateRoom = useCallback(
+    async (id: string, data: Record<string, unknown>) => {
+      try {
+        setError(null)
+        const updated = await window.electronAPI.roomUpdate(id, data)
+        await fetchRooms()
+        return updated
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "特別教室の更新に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchRooms]
+  )
+
+  const deleteRoom = useCallback(
+    async (id: string) => {
+      try {
+        setError(null)
+        await window.electronAPI.roomDelete(id)
+        await fetchRooms()
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "特別教室の削除に失敗しました"
+        )
+        throw err
+      }
+    },
+    [fetchRooms]
+  )
+
+  const upsertAvailability = useCallback(
+    async (data: {
+      roomId: string
+      dayOfWeek: number
+      period: number
+      status: string
+    }) => {
+      try {
+        setError(null)
+        await window.electronAPI.roomAvailabilityUpsert(data)
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "都合の更新に失敗しました"
+        )
+        throw err
+      }
+    },
+    []
+  )
+
+  useEffect(() => {
+    fetchRooms()
+  }, [fetchRooms])
+
+  return {
+    rooms,
+    loading,
+    error,
+    fetchRooms,
+    createRoom,
+    updateRoom,
+    deleteRoom,
+    upsertAvailability,
+  }
+}

--- a/hooks/useTeachers.ts
+++ b/hooks/useTeachers.ts
@@ -84,6 +84,7 @@ export function useTeachers() {
       try {
         setError(null)
         await window.electronAPI.teacherAvailabilityUpsert(data)
+        await fetchTeachers()
       } catch (err) {
         setError(
           err instanceof Error ? err.message : "都合の更新に失敗しました"
@@ -91,7 +92,7 @@ export function useTeachers() {
         throw err
       }
     },
-    []
+    [fetchTeachers]
   )
 
   const batchUpsertAvailabilities = useCallback(

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -38,6 +38,21 @@ export const AVAILABILITY_STATUS = {
   preferred: "希望",
 } as const
 
+export const ROOM_AVAILABILITY_STATUS = {
+  available: "可",
+  unavailable: "不可",
+} as const
+
+export const KOMA_TYPES = {
+  normal: "普通",
+  consecutive: "連続",
+} as const
+
+export const KOMA_TEACHER_ROLES = {
+  main: "主",
+  sub: "副",
+} as const
+
 export const COLOR_PALETTE = [
   "#EF4444",
   "#F59E0B",

--- a/lib/komaGenerator.ts
+++ b/lib/komaGenerator.ts
@@ -1,0 +1,88 @@
+// 学習指導要領に基づく中学校の標準時間割プリセット
+// 年間授業時数を35週で割った週あたりの時間数(概算)
+
+interface CurriculumItem {
+  subjectName: string
+  weeklyHours: number
+  type?: "normal" | "consecutive"
+}
+
+// 学年別プリセット (中学校)
+export const CURRICULUM_PRESETS: Record<number, CurriculumItem[]> = {
+  1: [
+    { subjectName: "国語", weeklyHours: 4 },
+    { subjectName: "社会", weeklyHours: 3 },
+    { subjectName: "数学", weeklyHours: 4 },
+    { subjectName: "理科", weeklyHours: 3 },
+    { subjectName: "英語", weeklyHours: 4 },
+    { subjectName: "音楽", weeklyHours: 1 },
+    { subjectName: "美術", weeklyHours: 1 },
+    { subjectName: "保健体育", weeklyHours: 3 },
+    { subjectName: "技術・家庭", weeklyHours: 2 },
+    { subjectName: "道徳", weeklyHours: 1 },
+    { subjectName: "学活", weeklyHours: 1 },
+    { subjectName: "総合", weeklyHours: 2 },
+  ],
+  2: [
+    { subjectName: "国語", weeklyHours: 4 },
+    { subjectName: "社会", weeklyHours: 3 },
+    { subjectName: "数学", weeklyHours: 3 },
+    { subjectName: "理科", weeklyHours: 4 },
+    { subjectName: "英語", weeklyHours: 4 },
+    { subjectName: "音楽", weeklyHours: 1 },
+    { subjectName: "美術", weeklyHours: 1 },
+    { subjectName: "保健体育", weeklyHours: 3 },
+    { subjectName: "技術・家庭", weeklyHours: 2 },
+    { subjectName: "道徳", weeklyHours: 1 },
+    { subjectName: "学活", weeklyHours: 1 },
+    { subjectName: "総合", weeklyHours: 2 },
+  ],
+  3: [
+    { subjectName: "国語", weeklyHours: 3 },
+    { subjectName: "社会", weeklyHours: 4 },
+    { subjectName: "数学", weeklyHours: 4 },
+    { subjectName: "理科", weeklyHours: 4 },
+    { subjectName: "英語", weeklyHours: 4 },
+    { subjectName: "音楽", weeklyHours: 1 },
+    { subjectName: "美術", weeklyHours: 1 },
+    { subjectName: "保健体育", weeklyHours: 3 },
+    { subjectName: "技術・家庭", weeklyHours: 1 },
+    { subjectName: "道徳", weeklyHours: 1 },
+    { subjectName: "学活", weeklyHours: 1 },
+    { subjectName: "総合", weeklyHours: 2 },
+  ],
+}
+
+/**
+ * プリセット設定から駒生成用のデータ配列を生成する純粋関数
+ */
+export function generateKomasFromPreset(
+  preset: Record<
+    string,
+    { count: number; type: string; enabled: boolean }
+  >,
+  gradeId: string,
+  subjects: { id: string; name: string }[]
+): { subjectId: string; gradeId: string; type: string; count: number }[] {
+  const result: {
+    subjectId: string
+    gradeId: string
+    type: string
+    count: number
+  }[] = []
+
+  for (const [subjectId, config] of Object.entries(preset)) {
+    if (!config.enabled || config.count <= 0) continue
+    const subject = subjects.find((s) => s.id === subjectId)
+    if (!subject) continue
+
+    result.push({
+      subjectId,
+      gradeId,
+      type: config.type,
+      count: config.count,
+    })
+  }
+
+  return result
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,18 +36,20 @@ model Grade {
   gradeNum  Int      @unique
   name      String   // "1年", "2年", "3年"
   classes   Class[]
+  komas     Koma[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
 
 model Class {
-  id        String   @id @default(cuid())
-  gradeId   String
-  grade     Grade    @relation(fields: [gradeId], references: [id], onDelete: Cascade)
-  name      String   // "1組", "2組" or "A組", "B組"
-  sortOrder Int      @default(0)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id          String       @id @default(cuid())
+  gradeId     String
+  grade       Grade        @relation(fields: [gradeId], references: [id], onDelete: Cascade)
+  name        String       // "1組", "2組" or "A組", "B組"
+  sortOrder   Int          @default(0)
+  komaClasses KomaClass[]
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
 
   @@unique([gradeId, name])
   @@index([gradeId])
@@ -59,11 +61,17 @@ model Teacher {
   nameKana       String               @default("")
   // 担当教科ID (メイン)
   mainSubjectId  String?
+  // 連続授業の最大数
+  maxConsecutive Int                   @default(6)
+  // 1日の最大授業数
+  maxPerDay      Int                   @default(6)
   // 週当たり最大コマ数
   maxPeriodsPerWeek Int               @default(25)
   // 備考
   notes          String               @default("")
   availabilities TeacherAvailability[]
+  teacherDuties  TeacherDuty[]
+  komaTeachers   KomaTeacher[]
   createdAt      DateTime             @default(now())
   updatedAt      DateTime             @updatedAt
 }
@@ -92,6 +100,129 @@ model Subject {
   category     String   @default("general")
   sortOrder    Int      @default(0)
   isDefault    Boolean  @default(false)
+  komas        Koma[]
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+}
+
+model SpecialRoom {
+  id             String             @id @default(cuid())
+  name           String
+  shortName      String             @default("")
+  // 収容可能人数
+  capacity       Int                @default(40)
+  notes          String             @default("")
+  sortOrder      Int                @default(0)
+  availabilities RoomAvailability[]
+  komaRooms      KomaRoom[]
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
+}
+
+model RoomAvailability {
+  id        String      @id @default(cuid())
+  roomId    String
+  room      SpecialRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  dayOfWeek Int         // 0=月, 1=火, 2=水, 3=木, 4=金, (5=土)
+  period    Int         // 1〜6 (0=0時限目)
+  // "available" | "unavailable"
+  status    String      @default("available")
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+
+  @@unique([roomId, dayOfWeek, period])
+  @@index([roomId])
+}
+
+model Duty {
+  id           String        @id @default(cuid())
+  name         String
+  shortName    String        @default("")
+  dayOfWeek    Int           // 0=月, 1=火, 2=水, 3=木, 4=金, (5=土)
+  period       Int           // 時限
+  sortOrder    Int           @default(0)
+  teacherDuties TeacherDuty[]
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+}
+
+model TeacherDuty {
+  id        String   @id @default(cuid())
+  dutyId    String
+  duty      Duty     @relation(fields: [dutyId], references: [id], onDelete: Cascade)
+  teacherId String
+  teacher   Teacher  @relation(fields: [teacherId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([dutyId, teacherId])
+  @@index([dutyId])
+  @@index([teacherId])
+}
+
+model Koma {
+  id           String        @id @default(cuid())
+  subjectId    String
+  subject      Subject       @relation(fields: [subjectId], references: [id], onDelete: Cascade)
+  gradeId      String
+  grade        Grade         @relation(fields: [gradeId], references: [id], onDelete: Cascade)
+  // "normal" | "consecutive"
+  type         String        @default("normal")
+  // 週あたり駒数
+  count        Int           @default(1)
+  // 優先順位 (0-9, 高いほど優先)
+  priority     Int           @default(5)
+  label        String        @default("")
+  komaTeachers KomaTeacher[]
+  komaClasses  KomaClass[]
+  komaRooms    KomaRoom[]
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+
+  @@index([subjectId])
+  @@index([gradeId])
+}
+
+model KomaTeacher {
+  id        String   @id @default(cuid())
+  komaId    String
+  koma      Koma     @relation(fields: [komaId], references: [id], onDelete: Cascade)
+  teacherId String
+  teacher   Teacher  @relation(fields: [teacherId], references: [id], onDelete: Cascade)
+  // "main" | "sub"
+  role      String   @default("main")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([komaId, teacherId])
+  @@index([komaId])
+  @@index([teacherId])
+}
+
+model KomaClass {
+  id        String   @id @default(cuid())
+  komaId    String
+  koma      Koma     @relation(fields: [komaId], references: [id], onDelete: Cascade)
+  classId   String
+  class_    Class    @relation(fields: [classId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([komaId, classId])
+  @@index([komaId])
+  @@index([classId])
+}
+
+model KomaRoom {
+  id        String      @id @default(cuid())
+  komaId    String
+  koma      Koma        @relation(fields: [komaId], references: [id], onDelete: Cascade)
+  roomId    String
+  room      SpecialRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+
+  @@unique([komaId, roomId])
+  @@index([komaId])
+  @@index([roomId])
 }

--- a/types/common.types.ts
+++ b/types/common.types.ts
@@ -38,9 +38,12 @@ export interface Teacher {
   name: string
   nameKana: string
   mainSubjectId: string | null
+  maxConsecutive: number
+  maxPerDay: number
   maxPeriodsPerWeek: number
   notes: string
   availabilities?: TeacherAvailability[]
+  teacherDuties?: TeacherDutyInfo[]
   createdAt: string
   updatedAt: string
 }
@@ -63,6 +66,95 @@ export interface Subject {
   category: string // "general" | "reserve" | "school_affair"
   sortOrder: number
   isDefault: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SpecialRoom {
+  id: string
+  name: string
+  shortName: string
+  capacity: number
+  notes: string
+  sortOrder: number
+  availabilities?: RoomAvailability[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface RoomAvailability {
+  id: string
+  roomId: string
+  dayOfWeek: number
+  period: number
+  status: string // "available" | "unavailable"
+  createdAt: string
+  updatedAt: string
+}
+
+export interface Duty {
+  id: string
+  name: string
+  shortName: string
+  dayOfWeek: number
+  period: number
+  sortOrder: number
+  teacherDuties?: TeacherDutyInfo[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TeacherDutyInfo {
+  id: string
+  dutyId: string
+  teacherId: string
+  teacher?: Teacher
+  duty?: Duty
+  createdAt: string
+  updatedAt: string
+}
+
+export interface Koma {
+  id: string
+  subjectId: string
+  gradeId: string
+  type: string // "normal" | "consecutive"
+  count: number
+  priority: number
+  label: string
+  subject?: Subject
+  grade?: Grade
+  komaTeachers?: KomaTeacher[]
+  komaClasses?: KomaClass[]
+  komaRooms?: KomaRoom[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface KomaTeacher {
+  id: string
+  komaId: string
+  teacherId: string
+  role: string // "main" | "sub"
+  teacher?: Teacher
+  createdAt: string
+  updatedAt: string
+}
+
+export interface KomaClass {
+  id: string
+  komaId: string
+  classId: string
+  class_?: ClassInfo
+  createdAt: string
+  updatedAt: string
+}
+
+export interface KomaRoom {
+  id: string
+  komaId: string
+  roomId: string
+  room?: SpecialRoom
   createdAt: string
   updatedAt: string
 }

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -101,6 +101,87 @@ export interface ElectronAPI {
   ) => Promise<import("./common.types").Subject[]>
   subjectSeedDefaults: () => Promise<void>
 
+  // SpecialRoom
+  roomGetAll: () => Promise<import("./common.types").SpecialRoom[]>
+  roomGetById: (
+    id: string
+  ) => Promise<import("./common.types").SpecialRoom | null>
+  roomCreate: (
+    data: Record<string, unknown>
+  ) => Promise<import("./common.types").SpecialRoom>
+  roomUpdate: (
+    id: string,
+    data: Record<string, unknown>
+  ) => Promise<import("./common.types").SpecialRoom>
+  roomDelete: (id: string) => Promise<import("./common.types").SpecialRoom>
+  roomGetWithAvailabilities: (
+    id: string
+  ) => Promise<import("./common.types").SpecialRoom | null>
+
+  // RoomAvailability
+  roomAvailabilityUpsert: (data: {
+    roomId: string
+    dayOfWeek: number
+    period: number
+    status: string
+  }) => Promise<import("./common.types").RoomAvailability>
+  roomAvailabilityBatchUpsert: (
+    items: {
+      roomId: string
+      dayOfWeek: number
+      period: number
+      status: string
+    }[]
+  ) => Promise<import("./common.types").RoomAvailability[]>
+  roomAvailabilityGetByRoomId: (
+    roomId: string
+  ) => Promise<import("./common.types").RoomAvailability[]>
+
+  // Duty
+  dutyGetAll: () => Promise<import("./common.types").Duty[]>
+  dutyGetById: (id: string) => Promise<import("./common.types").Duty | null>
+  dutyCreate: (
+    data: Record<string, unknown>
+  ) => Promise<import("./common.types").Duty>
+  dutyUpdate: (
+    id: string,
+    data: Record<string, unknown>
+  ) => Promise<import("./common.types").Duty>
+  dutyDelete: (id: string) => Promise<import("./common.types").Duty>
+  dutySetTeachers: (
+    dutyId: string,
+    teacherIds: string[]
+  ) => Promise<void>
+
+  // Koma
+  komaGetAll: () => Promise<import("./common.types").Koma[]>
+  komaGetById: (id: string) => Promise<import("./common.types").Koma | null>
+  komaGetByGradeId: (
+    gradeId: string
+  ) => Promise<import("./common.types").Koma[]>
+  komaCreate: (
+    data: Record<string, unknown>
+  ) => Promise<import("./common.types").Koma>
+  komaUpdate: (
+    id: string,
+    data: Record<string, unknown>
+  ) => Promise<import("./common.types").Koma>
+  komaDelete: (id: string) => Promise<import("./common.types").Koma>
+  komaDuplicate: (id: string) => Promise<import("./common.types").Koma>
+  komaSetTeachers: (
+    komaId: string,
+    teachers: { teacherId: string; role: string }[]
+  ) => Promise<void>
+  komaSetClasses: (komaId: string, classIds: string[]) => Promise<void>
+  komaSetRooms: (komaId: string, roomIds: string[]) => Promise<void>
+  komaBatchCreate: (
+    komas: Record<string, unknown>[]
+  ) => Promise<import("./common.types").Koma[]>
+  komaGetByTeacherId: (
+    teacherId: string
+  ) => Promise<import("./common.types").Koma[]>
+  komaDeleteByGradeId: (gradeId: string) => Promise<void>
+
   // Misc
   getAppVersion: () => Promise<string>
   getDataDirectoryInfo: () => Promise<{ path: string }>


### PR DESCRIPTION
## Summary
- Phase 2 データ入力モジュール実装（特別教室・校務・駒設定の CRUD + UI）
- Phase 1 先生設定ページのバグ修正（先生名変更不可・都合マトリクス未更新）
- `.gitignore` の `data/` パターン修正（`app/data/` が除外されていた問題）

## 変更内容

### Phase 2: データ入力機能（新規）
- 特別教室設定: DAL/IPC/Hook/Page + AvailabilityGrid（2状態サイクル対応）
- 校務設定: DAL/IPC/Hook/Page + 担当先生チェックボックス
- 駒設定: DAL/IPC/Hook/Page + カリキュラムプリセット一括生成
- 先生持ち駒タブ: TeacherKomaList コンポーネント
- ダッシュボード + ナビゲーション: 3項目追加

### 先生設定バグ修正
- 先生名 Input: `value`/`defaultValue` 混在を `key` + `defaultValue` + `onBlur` パターンに統一
- 都合マトリクス: `upsertAvailability` 後に `fetchTeachers()` で state 更新
- 新フィールド: 連続授業最大数 (`maxConsecutive`)・1日最大授業数 (`maxPerDay`)
- 携わる校務: TeacherDuty 経由でバッジ表示

### スキーマ・DB
- Prisma: 8新モデル (SpecialRoom, RoomAvailability, Duty, TeacherDuty, Koma, KomaTeacher, KomaClass, KomaRoom)
- Teacher モデル: `maxConsecutive`, `maxPerDay` 追加
- DB 初期化 + マイグレーション対応

## Test plan
- [ ] `npm run build` エラーなし
- [ ] 先生名を編集して onBlur で保存されること
- [ ] 都合マトリクスのクリックで即座に UI 更新されること
- [ ] 特別教室の CRUD + 使用可能時間設定が動作すること
- [ ] 校務の CRUD + 担当先生割当が動作すること
- [ ] 駒の一括生成が動作すること

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)