### PR TITLE
feat: Playwright E2Eテスト導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 
 # testing
 coverage/
+test-results/
+playwright-report/
 
 # next.js
 .next/

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,56 @@
+import { test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+
+import { type AppContext, closeApp, expect, launchApp } from "./helpers/fixtures"
+
+let ctx: AppContext
+let page: Page
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+  page = ctx.page
+})
+
+test.afterAll(async () => {
+  await closeApp(ctx)
+})
+
+test("ダッシュボードが表示される", async () => {
+  await expect(page.locator("h1")).toHaveText("一括時間割作成")
+  await expect(page.locator("h2").first()).toHaveText("初期設定")
+  await expect(page.locator("h2").nth(1)).toHaveText("データ入力")
+})
+
+test("全ナビカード（8枚）が存在する", async () => {
+  const titles = [
+    "学校基本設定",
+    "科目設定",
+    "基本時間割枠",
+    "先生設定",
+    "クラス設定",
+    "特別教室",
+    "校務",
+    "駒設定",
+  ]
+  for (const title of titles) {
+    await expect(page.getByText(title, { exact: false }).first()).toBeVisible()
+  }
+})
+
+test("学校基本設定カードから遷移できる", async () => {
+  await page.getByText("学校基本設定").first().click()
+  await expect(page.getByText("学校基本設定").first()).toBeVisible()
+  await page.goBack()
+})
+
+test("科目設定カードから遷移できる", async () => {
+  await page.getByText("科目設定").first().click()
+  await expect(page.getByText("科目設定").first()).toBeVisible()
+  await page.goBack()
+})
+
+test("先生設定カードから遷移できる", async () => {
+  await page.getByText("先生設定").first().click()
+  await expect(page.getByText("先生設定").first()).toBeVisible()
+  await page.goBack()
+})

--- a/e2e/duties.spec.ts
+++ b/e2e/duties.spec.ts
@@ -1,0 +1,110 @@
+import { test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+
+import {
+  type AppContext,
+  closeApp,
+  expect,
+  launchApp,
+  TEST_BASE_URL,
+} from "./helpers/fixtures"
+
+let ctx: AppContext
+let page: Page
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+  page = ctx.page
+
+  // 校務テストには先生が必要なので先に追加
+  await page.goto(`${TEST_BASE_URL}/data/teachers`, {
+    waitUntil: "domcontentloaded",
+  })
+  await page.waitForTimeout(1000)
+  await page.getByRole("button", { name: "先生を追加" }).click()
+  await page.getByPlaceholder("例: 山田太郎").fill("田中太郎")
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "追加" })
+    .click()
+  await expect(page.getByText("先生を追加しました")).toBeVisible()
+
+  await page.goto(`${TEST_BASE_URL}/data/duties`, {
+    waitUntil: "domcontentloaded",
+  })
+  await page.waitForTimeout(1000)
+})
+
+test.afterAll(async () => {
+  await closeApp(ctx)
+})
+
+test("校務設定ページが表示される", async () => {
+  await expect(page.getByText("校務設定").first()).toBeVisible()
+  await expect(page.getByText("校務がありません")).toBeVisible()
+})
+
+test("校務を追加できる", async () => {
+  await page.getByRole("button", { name: "校務を追加" }).click()
+
+  await expect(page.getByRole("heading", { name: "校務を追加" })).toBeVisible()
+
+  await page
+    .getByPlaceholder("例: 給食指導", { exact: true })
+    .fill("給食指導")
+  await page.getByPlaceholder("例: 給", { exact: true }).fill("給")
+
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "追加" })
+    .click()
+  await expect(page.getByText("校務を追加しました")).toBeVisible()
+  await expect(page.getByText("給食指導")).toBeVisible()
+})
+
+test("校務の基本情報を編集できる", async () => {
+  // Detail panel input (first match = detail, second = dialog)
+  const nameInput = page
+    .getByText("校務名", { exact: true })
+    .first()
+    .locator("xpath=..")
+    .locator("input")
+  await nameInput.fill("昼食指導")
+  await nameInput.blur()
+
+  await page.waitForTimeout(500)
+
+  await page.goto(`${TEST_BASE_URL}/data/duties`, {
+    waitUntil: "domcontentloaded",
+  })
+  await page.waitForTimeout(1000)
+  await page.getByText("昼食指導").click()
+
+  const updatedInput = page
+    .getByText("校務名", { exact: true })
+    .first()
+    .locator("xpath=..")
+    .locator("input")
+  await expect(updatedInput).toHaveValue("昼食指導")
+})
+
+test("担当先生タブが表示される", async () => {
+  await page.getByRole("tab", { name: "担当先生" }).click()
+  await expect(page.getByText("田中太郎")).toBeVisible()
+})
+
+test("担当先生を割り当てられる", async () => {
+  const checkbox = page.locator('[id^="teacher-"]').first()
+  await checkbox.click()
+  await page.waitForTimeout(500)
+
+  await page.goto(`${TEST_BASE_URL}/data/duties`, {
+    waitUntil: "domcontentloaded",
+  })
+  await page.waitForTimeout(1000)
+  await page.getByText("昼食指導").click()
+  await page.getByRole("tab", { name: "担当先生" }).click()
+
+  const checkboxAfterReload = page.locator('[id^="teacher-"]').first()
+  await expect(checkboxAfterReload).toBeChecked()
+})

--- a/e2e/helpers/electron-app.ts
+++ b/e2e/helpers/electron-app.ts
@@ -1,0 +1,54 @@
+import {
+  _electron,
+  type ElectronApplication,
+  type Page,
+} from "@playwright/test"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+
+export const TEST_PORT = "3100"
+export const TEST_BASE_URL = `http://localhost:${TEST_PORT}`
+
+export interface AppContext {
+  electronApp: ElectronApplication
+  page: Page
+  tmpDir: string
+}
+
+export async function launchApp(): Promise<AppContext> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "timetable-test-"))
+
+  const electronApp = await _electron.launch({
+    args: [path.resolve("main/electron-src/index.js")],
+    env: {
+      ...process.env,
+      TIMETABLE_DATA_DIR: tmpDir,
+      NODE_ENV: "test",
+      NEXT_SERVER_PORT: TEST_PORT,
+    },
+  })
+
+  const page = await electronApp.firstWindow()
+  // firstWindow() returns when the BrowserWindow is created, but the URL
+  // may not be loaded yet (Electron checks server readiness first).
+  // Wait for the actual Next.js URL to be loaded.
+  await page.waitForURL(/localhost/, { timeout: 30_000 })
+  await page.waitForLoadState("domcontentloaded")
+
+  return { electronApp, page, tmpDir }
+}
+
+export async function closeApp(ctx: AppContext): Promise<void> {
+  try {
+    await ctx.electronApp.close()
+  } catch {
+    // ignore close errors
+  }
+
+  try {
+    fs.rmSync(ctx.tmpDir, { recursive: true, force: true })
+  } catch {
+    // ignore cleanup errors
+  }
+}

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -1,0 +1,9 @@
+import { expect } from "@playwright/test"
+
+export { expect }
+export {
+  type AppContext,
+  closeApp,
+  launchApp,
+  TEST_BASE_URL,
+} from "./electron-app"

--- a/e2e/koma.spec.ts
+++ b/e2e/koma.spec.ts
@@ -1,0 +1,64 @@
+import { test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+
+import {
+  type AppContext,
+  closeApp,
+  expect,
+  launchApp,
+  TEST_BASE_URL,
+} from "./helpers/fixtures"
+
+let ctx: AppContext
+let page: Page
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+  page = ctx.page
+
+  // 駒テストには学年が必要なので先に学校設定を保存
+  await page.goto(`${TEST_BASE_URL}/setup/school`, {
+    waitUntil: "domcontentloaded",
+  })
+  await page.locator("#schoolName").fill("テスト中学校")
+  await page.getByRole("button", { name: "保存" }).click()
+  await expect(page.getByText("学校基本設定を保存しました")).toBeVisible()
+
+  await page.goto(`${TEST_BASE_URL}/data/koma`, {
+    waitUntil: "domcontentloaded",
+  })
+})
+
+test.afterAll(async () => {
+  await closeApp(ctx)
+})
+
+test("駒設定ページが表示される", async () => {
+  await expect(page.getByText("駒設定").first()).toBeVisible()
+})
+
+test("学年タブが存在する", async () => {
+  await expect(page.getByText("1年").first()).toBeVisible()
+  await expect(page.getByText("2年").first()).toBeVisible()
+  await expect(page.getByText("3年").first()).toBeVisible()
+})
+
+test("一括生成ダイアログを開ける", async () => {
+  await page.getByRole("button", { name: "一括生成" }).click()
+  await expect(page.getByRole("dialog")).toBeVisible()
+
+  await page.keyboard.press("Escape")
+})
+
+test("駒を追加できる", async () => {
+  await page.getByRole("button", { name: "駒を追加" }).click()
+  await expect(page.getByText("駒を追加しました")).toBeVisible()
+})
+
+test("学年タブを切り替えられる", async () => {
+  await page.getByText("2年").first().click()
+  await page.waitForTimeout(500)
+
+  await page.getByText("1年").first().click()
+  await page.waitForTimeout(500)
+})

--- a/e2e/rooms.spec.ts
+++ b/e2e/rooms.spec.ts
@@ -1,0 +1,95 @@
+import { test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+
+import {
+  type AppContext,
+  closeApp,
+  expect,
+  launchApp,
+  TEST_BASE_URL,
+} from "./helpers/fixtures"
+
+let ctx: AppContext
+let page: Page
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+  page = ctx.page
+  await page.goto(`${TEST_BASE_URL}/data/rooms`, {
+    waitUntil: "domcontentloaded",
+  })
+  await page.waitForTimeout(1000)
+})
+
+test.afterAll(async () => {
+  await closeApp(ctx)
+})
+
+test("特別教室設定ページが表示される", async () => {
+  await expect(page.getByText("特別教室設定").first()).toBeVisible()
+  await expect(page.getByText("特別教室がありません")).toBeVisible()
+})
+
+test("特別教室を追加できる", async () => {
+  await page.getByRole("button", { name: "教室を追加" }).click()
+
+  await expect(
+    page.getByRole("heading", { name: "特別教室を追加" })
+  ).toBeVisible()
+
+  await page.getByPlaceholder("例: 音楽室", { exact: true }).fill("音楽室")
+  await page.getByPlaceholder("例: 音", { exact: true }).fill("音")
+
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "追加" })
+    .click()
+  await expect(page.getByText("特別教室を追加しました")).toBeVisible()
+  await expect(page.getByText("音楽室")).toBeVisible()
+})
+
+test("教室の基本情報を編集できる", async () => {
+  // Detail panel input (first match = detail, second = dialog)
+  const nameInput = page
+    .getByText("教室名", { exact: true })
+    .first()
+    .locator("xpath=..")
+    .locator("input")
+  await nameInput.fill("第1音楽室")
+  await nameInput.blur()
+
+  await page.waitForTimeout(500)
+
+  await page.goto(`${TEST_BASE_URL}/data/rooms`, {
+    waitUntil: "domcontentloaded",
+  })
+  await page.waitForTimeout(1000)
+  await page.getByText("第1音楽室").click()
+
+  const updatedInput = page
+    .getByText("教室名", { exact: true })
+    .first()
+    .locator("xpath=..")
+    .locator("input")
+  await expect(updatedInput).toHaveValue("第1音楽室")
+})
+
+test("使用可能時間タブが表示される", async () => {
+  await page.getByRole("tab", { name: "都合" }).click()
+  await expect(
+    page.getByText("使用可能時間", { exact: true })
+  ).toBeVisible()
+})
+
+test("2つ目の教室を追加できる", async () => {
+  await page.getByRole("tab", { name: "基本情報" }).click()
+  await page.getByRole("button", { name: "教室を追加" }).click()
+  await page.getByPlaceholder("例: 音楽室", { exact: true }).fill("理科室")
+  await page.getByPlaceholder("例: 音", { exact: true }).fill("理")
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "追加" })
+    .click()
+  await expect(page.getByText("特別教室を追加しました")).toBeVisible()
+  await expect(page.getByText("理科室")).toBeVisible()
+})

--- a/e2e/setup-school.spec.ts
+++ b/e2e/setup-school.spec.ts
@@ -1,0 +1,66 @@
+import { test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+
+import {
+  type AppContext,
+  closeApp,
+  expect,
+  launchApp,
+  TEST_BASE_URL,
+} from "./helpers/fixtures"
+
+let ctx: AppContext
+let page: Page
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+  page = ctx.page
+  await page.goto(`${TEST_BASE_URL}/setup/school`, {
+    waitUntil: "domcontentloaded",
+  })
+})
+
+test.afterAll(async () => {
+  await closeApp(ctx)
+})
+
+test("学校基本設定ページが表示される", async () => {
+  await expect(page.getByText("学校基本設定").first()).toBeVisible()
+  await expect(page.getByText("基本情報", { exact: true }).first()).toBeVisible()
+  await expect(page.getByText("学級構成", { exact: true }).first()).toBeVisible()
+})
+
+test("学校名を入力・保存できる", async () => {
+  const nameInput = page.locator("#schoolName")
+  await nameInput.fill("テスト中学校")
+  await expect(nameInput).toHaveValue("テスト中学校")
+
+  await page.getByRole("button", { name: "保存" }).click()
+  await expect(page.getByText("学校基本設定を保存しました")).toBeVisible()
+})
+
+test("年度を変更できる", async () => {
+  const yearInput = page.locator("#academicYear")
+  await yearInput.fill("2026")
+  await expect(yearInput).toHaveValue("2026")
+})
+
+test("学級数を設定できる", async () => {
+  const gradeInputs = page.locator('input[type="number"][min="1"][max="20"]')
+  await expect(gradeInputs).toHaveCount(3)
+
+  await gradeInputs.nth(0).fill("3")
+  await expect(gradeInputs.nth(0)).toHaveValue("3")
+})
+
+test("保存後にリロードしても値が保持される", async () => {
+  await page.getByRole("button", { name: "保存" }).click()
+  await expect(page.getByText("学校基本設定を保存しました")).toBeVisible()
+
+  await page.goto(`${TEST_BASE_URL}/setup/school`, {
+    waitUntil: "domcontentloaded",
+  })
+
+  const nameInput = page.locator("#schoolName")
+  await expect(nameInput).toHaveValue("テスト中学校")
+})

--- a/e2e/setup-subjects.spec.ts
+++ b/e2e/setup-subjects.spec.ts
@@ -1,0 +1,90 @@
+import { test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+
+import {
+  type AppContext,
+  closeApp,
+  expect,
+  launchApp,
+  TEST_BASE_URL,
+} from "./helpers/fixtures"
+
+let ctx: AppContext
+let page: Page
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+  page = ctx.page
+  await page.goto(`${TEST_BASE_URL}/setup/subjects`, {
+    waitUntil: "domcontentloaded",
+  })
+  // Wait for IPC data to load
+  await page.waitForTimeout(2000)
+})
+
+test.afterAll(async () => {
+  await closeApp(ctx)
+})
+
+test("科目設定ページが表示される", async () => {
+  await expect(page.getByText("科目設定").first()).toBeVisible()
+  await expect(page.getByRole("tab", { name: "一般教科" })).toBeVisible()
+})
+
+test("デフォルト科目が表示される", async () => {
+  // Note: table cell text includes Badge "既定" (e.g. "国語既定"), so exact match won't work
+  const table = page.locator("table").first()
+  await expect(table.getByText("国語").first()).toBeVisible({ timeout: 15_000 })
+  await expect(table.getByText("数学").first()).toBeVisible()
+  await expect(table.getByText("英語").first()).toBeVisible()
+})
+
+test("科目を追加できる", async () => {
+  await page.getByRole("button", { name: "追加" }).first().click()
+
+  await expect(page.getByText("科目を追加")).toBeVisible()
+
+  await page.getByPlaceholder("例: 国語").fill("プログラミング")
+  await page.getByPlaceholder("例: 国", { exact: true }).fill("プ")
+
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "保存" })
+    .click()
+  await expect(page.getByText("科目を追加しました")).toBeVisible()
+  await expect(page.getByText("プログラミング")).toBeVisible()
+})
+
+test("科目を編集できる", async () => {
+  const row = page.locator("tr").filter({ hasText: "プログラミング" })
+  await row.locator("button").first().click()
+
+  await expect(page.getByText("科目を編集")).toBeVisible()
+
+  const nameInput = page.getByPlaceholder("例: 国語")
+  await nameInput.fill("情報")
+
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "保存" })
+    .click()
+  await expect(page.getByText("科目を更新しました")).toBeVisible()
+  await expect(page.getByText("情報")).toBeVisible()
+})
+
+test("追加した科目を削除できる", async () => {
+  const row = page.locator("tr").filter({ hasText: "情報" })
+  await row.locator("button").last().click()
+
+  await expect(page.getByText("科目を削除しました")).toBeVisible()
+})
+
+test("タブを切り替えられる", async () => {
+  await page
+    .getByRole("tab", { name: "予備（学活・道徳・総合等）" })
+    .click()
+  await expect(page.getByText("道徳").first()).toBeVisible()
+
+  await page.getByRole("tab", { name: "校務" }).click()
+  await page.getByRole("tab", { name: "一般教科" }).click()
+})

--- a/e2e/teachers.spec.ts
+++ b/e2e/teachers.spec.ts
@@ -1,0 +1,108 @@
+import { test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+
+import {
+  type AppContext,
+  closeApp,
+  expect,
+  launchApp,
+  TEST_BASE_URL,
+} from "./helpers/fixtures"
+
+let ctx: AppContext
+let page: Page
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+  page = ctx.page
+  await page.goto(`${TEST_BASE_URL}/data/teachers`, {
+    waitUntil: "domcontentloaded",
+  })
+  await page.waitForTimeout(1000)
+})
+
+test.afterAll(async () => {
+  await closeApp(ctx)
+})
+
+test("先生設定ページが表示される", async () => {
+  await expect(page.getByText("先生設定").first()).toBeVisible()
+  await expect(page.getByText("先生がいません")).toBeVisible()
+})
+
+test("先生を追加できる", async () => {
+  await page.getByRole("button", { name: "先生を追加" }).click()
+
+  await expect(page.getByRole("heading", { name: "先生を追加" })).toBeVisible()
+
+  await page.getByPlaceholder("例: 山田太郎").fill("山田太郎")
+  await page.getByPlaceholder("例: やまだたろう").fill("やまだたろう")
+
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "追加" })
+    .click()
+  await expect(page.getByText("先生を追加しました")).toBeVisible()
+  await expect(page.getByText("山田太郎")).toBeVisible()
+})
+
+test("先生名を編集（onBlur で保存）できる", async () => {
+  // Detail panel's name input
+  const nameInput = page
+    .getByText("先生名", { exact: true })
+    .first()
+    .locator("xpath=..")
+    .locator("input")
+  await nameInput.fill("山田花子")
+  await nameInput.blur()
+
+  await page.waitForTimeout(500)
+
+  await page.goto(`${TEST_BASE_URL}/data/teachers`, {
+    waitUntil: "domcontentloaded",
+  })
+  await page.waitForTimeout(1000)
+  await page.getByText("山田花子").click()
+
+  const updatedInput = page
+    .getByText("先生名", { exact: true })
+    .first()
+    .locator("xpath=..")
+    .locator("input")
+  await expect(updatedInput).toHaveValue("山田花子")
+})
+
+test("都合タブが表示される", async () => {
+  await page.getByRole("tab", { name: "都合" }).click()
+  await expect(page.getByText("都合マトリクス")).toBeVisible()
+})
+
+test("持ち駒タブが表示される", async () => {
+  await page.getByRole("tab", { name: "持ち駒" }).click()
+  await expect(
+    page.locator('[role="tabpanel"]').getByText("持ち駒")
+  ).toBeVisible()
+})
+
+test("2人目の先生を追加できる", async () => {
+  await page.getByRole("button", { name: "先生を追加" }).click()
+  await page.getByPlaceholder("例: 山田太郎").fill("鈴木一郎")
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "追加" })
+    .click()
+  await expect(page.getByText("先生を追加しました")).toBeVisible()
+  await expect(page.getByText("鈴木一郎")).toBeVisible()
+})
+
+test("先生を選択して切り替えられる", async () => {
+  await page.getByText("山田花子").click()
+  // Ensure the "基本情報" tab is active
+  await page.getByRole("tab", { name: "基本情報" }).click()
+  const nameInput = page
+    .getByText("先生名", { exact: true })
+    .first()
+    .locator("xpath=..")
+    .locator("input")
+  await expect(nameInput).toHaveValue("山田花子")
+})

--- a/electron-src/lib/dataManager.ts
+++ b/electron-src/lib/dataManager.ts
@@ -16,6 +16,9 @@ export const getAppRootPath = (): string => {
 }
 
 export const getDataDirectory = (): string => {
+  if (process.env.TIMETABLE_DATA_DIR) {
+    return process.env.TIMETABLE_DATA_DIR
+  }
   return path.join(getAppRootPath(), "data")
 }
 

--- a/electron-src/windowManager.ts
+++ b/electron-src/windowManager.ts
@@ -20,7 +20,8 @@ export function createMainWindow(): BrowserWindow {
     },
   })
 
-  const url = "http://localhost:3000"
+  const port = process.env.NEXT_SERVER_PORT || "3000"
+  const url = `http://localhost:${port}`
 
   Menu.setApplicationMenu(menu(app, mainWindow))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@electron-forge/maker-zip": "^7.11.1",
         "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
         "@eslint/eslintrc": "^3.3.3",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.1.18",
         "@types/node": "^25.1.0",
         "@types/react": "^19.2.10",
@@ -2561,6 +2562,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -8500,6 +8517,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -11799,6 +11830,38 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit && tsc -p ./electron-src/tsconfig.json",
     "check-all": "npm run typecheck && npm run lint",
+    "test:e2e": "npm run build && npx playwright test",
+    "test:e2e:headed": "npm run build && npx playwright test --headed",
     "postinstall": "prisma generate"
   },
   "dependencies": {
@@ -55,6 +57,7 @@
     "@electron-forge/maker-zip": "^7.11.1",
     "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
     "@eslint/eslintrc": "^3.3.3",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^25.1.0",
     "@types/react": "^19.2.10",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [["html", { open: "never" }]],
+  webServer: {
+    command: "npx next start -p 3100",
+    port: 3100,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+})


### PR DESCRIPTION
## Summary
- Playwright の Electron サポートを使った E2E テストインフラを導入
- 全7ページ・38テストケースで UI → IPC → Prisma → SQLite の全スタックを検証
- テスト専用の一時 DB 分離により本番データに影響なし

## 変更内容
| ファイル | 変更 |
|---------|------|
| `playwright.config.ts` | Playwright 設定（新規） |
| `e2e/helpers/` | Electron 起動・終了ユーティリティ（新規） |
| `e2e/*.spec.ts` | 7ファイル・38テストケース（新規） |
| `electron-src/lib/dataManager.ts` | `TIMETABLE_DATA_DIR` 環境変数対応 |
| `electron-src/windowManager.ts` | `NEXT_SERVER_PORT` 環境変数対応 |
| `package.json` | `test:e2e` スクリプト追加、`@playwright/test` 追加 |
| `.gitignore` | `test-results/` `playwright-report/` 除外追加 |

## Test plan
- [x] `npm run build` 成功
- [x] `npx playwright test` で全38テスト PASS

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)