### PR TITLE
chore: 開発・本番サーバーのポートを3000から3939に変更

### DIFF
--- a/electron-src/nextServerEmbedded.ts
+++ b/electron-src/nextServerEmbedded.ts
@@ -42,7 +42,7 @@ export async function startEmbeddedNextServer(): Promise<void> {
   try {
     const { createServer } = require("http")
     const hostname = "localhost"
-    const port = 3000
+    const port = 3939
 
     let appDir
     if (process.resourcesPath) {

--- a/electron-src/windowManager.ts
+++ b/electron-src/windowManager.ts
@@ -20,7 +20,7 @@ export function createMainWindow(): BrowserWindow {
     },
   })
 
-  const port = process.env.NEXT_SERVER_PORT || "3000"
+  const port = process.env.NEXT_SERVER_PORT || "3939"
   const url = `http://localhost:${port}`
 
   Menu.setApplicationMenu(menu(app, mainWindow))

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -18,7 +18,7 @@ async function startDev() {
 
   console.log("Starting Next.js...")
 
-  const nextProcess = spawn("npx", ["next", "dev"], {
+  const nextProcess = spawn("npx", ["next", "dev", "-p", "3939"], {
     stdio: "inherit",
     shell: true,
   })


### PR DESCRIPTION
## Summary
- 開発サーバー・本番埋め込みサーバーのポートを3000から3939に変更
- ポート競合を回避し、他プロジェクトとの共存を容易にする

Closes #9

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `scripts/dev.js` | `next dev -p 3939` を指定 |
| `electron-src/nextServerEmbedded.ts` | 埋め込みサーバーポートを3939に変更 |
| `electron-src/windowManager.ts` | デフォルトポートを3939に変更 |

## Test plan
- [ ] `npm run dev` でポート3939でNext.jsが起動することを確認
- [ ] Electronウィンドウがポート3939に接続することを確認
- [ ] `npm run test:e2e` がポート3100で正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)