### PR TITLE
ソルバー制約重み改善・教科別条件レベル追加・駒管理UIリファクタリング

### DIFF
--- a/app/data/koma/page.tsx
+++ b/app/data/koma/page.tsx
@@ -1,60 +1,33 @@
 "use client"
 
-import { Copy, Plus, Trash2 } from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 
+import { LessonTable } from "@/components/lesson/LessonTable"
+import { PresetDialog } from "@/components/lesson/PresetDialog"
 import { PageHeader } from "@/components/layout/PageHeader"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Checkbox } from "@/components/ui/checkbox"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
-import { ScrollArea } from "@/components/ui/scroll-area"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useClasses } from "@/hooks/useClasses"
 import { useKomas } from "@/hooks/useKomas"
 import { useRooms } from "@/hooks/useRooms"
 import { useSubjects } from "@/hooks/useSubjects"
 import { useTeachers } from "@/hooks/useTeachers"
-import { KOMA_TEACHER_ROLES, KOMA_TYPES } from "@/lib/constants"
-import {
-  CURRICULUM_PRESETS,
-  generateKomasFromPreset,
-} from "@/lib/komaGenerator"
-import type { Grade, Koma } from "@/types/common.types"
 
-export default function KomaPage() {
+export default function LessonPage() {
   const { grades, classes } = useClasses()
   const { subjects } = useSubjects()
   const { teachers } = useTeachers()
   const { rooms } = useRooms()
 
   const [selectedGradeId, setSelectedGradeId] = useState<string | null>(null)
+  const [presetOpen, setPresetOpen] = useState(false)
 
-  // selectedGradeId に基づいて useKomas を呼ぶ
   const {
     komas,
     loading,
     createKoma,
     updateKoma,
     deleteKoma,
-    duplicateKoma,
     setKomaTeachers,
     setKomaClasses,
     setKomaRooms,
@@ -62,239 +35,79 @@ export default function KomaPage() {
     deleteKomasByGrade,
   } = useKomas(selectedGradeId ?? undefined)
 
-  const [selectedKomaId, setSelectedKomaId] = useState<string | null>(null)
-  const [createDialogOpen, setCreateDialogOpen] = useState(false)
-  const [batchDialogOpen, setBatchDialogOpen] = useState(false)
-
-  const selectedKoma = komas.find((k) => k.id === selectedKomaId)
-
-  // 学年が変わったら先頭の駒を選択
   useEffect(() => {
     if (grades.length > 0 && !selectedGradeId) {
       setSelectedGradeId(grades[0].id)
     }
   }, [grades, selectedGradeId])
 
-  useEffect(() => {
-    setSelectedKomaId(null)
-  }, [selectedGradeId])
-
-  useEffect(() => {
-    if (komas.length > 0 && !selectedKomaId) {
-      setSelectedKomaId(komas[0].id)
-    }
-  }, [komas, selectedKomaId])
-
-  // 教科別にグループ化
-  const komasBySubject = useMemo(() => {
-    const groups: Record<
-      string,
-      { subject: { id: string; name: string; color: string }; komas: Koma[] }
-    > = {}
-    for (const koma of komas) {
-      const subjectId = koma.subjectId
-      if (!groups[subjectId]) {
-        groups[subjectId] = {
-          subject: koma.subject ?? {
-            id: subjectId,
-            name: "不明",
-            color: "#999",
-          },
-          komas: [],
-        }
-      }
-      groups[subjectId].komas.push(koma)
-    }
-    return Object.values(groups)
-  }, [komas])
-
-  // 該当学年のクラス
   const gradeClasses = useMemo(
-    () => classes.filter((c) => c.gradeId === selectedGradeId),
+    () =>
+      classes
+        .filter((c) => c.gradeId === selectedGradeId)
+        .sort((a, b) => a.sortOrder - b.sortOrder),
     [classes, selectedGradeId]
   )
 
-  const handleCreateKoma = useCallback(async () => {
-    if (!selectedGradeId || subjects.length === 0) return
-    try {
-      const created = await createKoma({
-        subjectId: subjects[0].id,
-        gradeId: selectedGradeId,
-      })
-      setSelectedKomaId(created.id)
-      setCreateDialogOpen(false)
-      toast.success("駒を追加しました")
-    } catch {
-      toast.error("追加に失敗しました")
-    }
-  }, [selectedGradeId, subjects, createKoma])
+  // プリセットから一括生成（クラス単位で駒を作成）
+  const handlePresetGenerate = useCallback(
+    async (
+      gradeId: string,
+      items: { subjectId: string; count: number; type: string }[]
+    ) => {
+      const targetClasses = classes
+        .filter((c) => c.gradeId === gradeId)
+        .sort((a, b) => a.sortOrder - b.sortOrder)
 
-  const handleDeleteKoma = useCallback(
-    async (koma: Koma) => {
-      try {
-        await deleteKoma(koma.id)
-        if (selectedKomaId === koma.id) {
-          setSelectedKomaId(null)
-        }
-        toast.success("駒を削除しました")
-      } catch {
-        toast.error("削除に失敗しました")
+      if (targetClasses.length === 0) {
+        toast.error("対象学年にクラスがありません")
+        return
       }
-    },
-    [deleteKoma, selectedKomaId]
-  )
 
-  const handleDuplicateKoma = useCallback(
-    async (koma: Koma) => {
-      try {
-        const duplicated = await duplicateKoma(koma.id)
-        if (duplicated) setSelectedKomaId(duplicated.id)
-        toast.success("駒をコピーしました")
-      } catch {
-        toast.error("コピーに失敗しました")
-      }
-    },
-    [duplicateKoma]
-  )
+      // 各教科 × クラス数 分の駒を生成
+      const komasData: Record<string, unknown>[] = []
+      const classAssignments: { komaIndex: number; classId: string }[] = []
 
-  const handleUpdateField = useCallback(
-    async (field: string, value: unknown) => {
-      if (!selectedKoma) return
-      try {
-        await updateKoma(selectedKoma.id, { [field]: value })
-      } catch {
-        toast.error("更新に失敗しました")
-      }
-    },
-    [selectedKoma, updateKoma]
-  )
-
-  const handleTeacherToggle = useCallback(
-    async (teacherId: string, checked: boolean) => {
-      if (!selectedKoma) return
-      const current = selectedKoma.komaTeachers ?? []
-      const newTeachers = checked
-        ? [
-            ...current.map((kt) => ({
-              teacherId: kt.teacherId,
-              role: kt.role,
-            })),
-            { teacherId, role: "main" },
-          ]
-        : current
-            .filter((kt) => kt.teacherId !== teacherId)
-            .map((kt) => ({ teacherId: kt.teacherId, role: kt.role }))
-      try {
-        await setKomaTeachers(selectedKoma.id, newTeachers)
-      } catch {
-        toast.error("先生の設定に失敗しました")
-      }
-    },
-    [selectedKoma, setKomaTeachers]
-  )
-
-  const handleTeacherRoleChange = useCallback(
-    async (teacherId: string, role: string) => {
-      if (!selectedKoma) return
-      const current = selectedKoma.komaTeachers ?? []
-      const newTeachers = current.map((kt) => ({
-        teacherId: kt.teacherId,
-        role: kt.teacherId === teacherId ? role : kt.role,
-      }))
-      try {
-        await setKomaTeachers(selectedKoma.id, newTeachers)
-      } catch {
-        toast.error("役割の変更に失敗しました")
-      }
-    },
-    [selectedKoma, setKomaTeachers]
-  )
-
-  const handleClassToggle = useCallback(
-    async (classId: string, checked: boolean) => {
-      if (!selectedKoma) return
-      const currentIds = selectedKoma.komaClasses?.map((kc) => kc.classId) ?? []
-      const newIds = checked
-        ? [...currentIds, classId]
-        : currentIds.filter((id) => id !== classId)
-      try {
-        await setKomaClasses(selectedKoma.id, newIds)
-      } catch {
-        toast.error("クラスの設定に失敗しました")
-      }
-    },
-    [selectedKoma, setKomaClasses]
-  )
-
-  const handleRoomToggle = useCallback(
-    async (roomId: string, checked: boolean) => {
-      if (!selectedKoma) return
-      const currentIds = selectedKoma.komaRooms?.map((kr) => kr.roomId) ?? []
-      const newIds = checked
-        ? [...currentIds, roomId]
-        : currentIds.filter((id) => id !== roomId)
-      try {
-        await setKomaRooms(selectedKoma.id, newIds)
-      } catch {
-        toast.error("教室の設定に失敗しました")
-      }
-    },
-    [selectedKoma, setKomaRooms]
-  )
-
-  // 一括生成
-  const [batchGradeId, setBatchGradeId] = useState<string>("")
-  const [batchPreset, setBatchPreset] = useState<
-    Record<string, { count: number; type: string; enabled: boolean }>
-  >({})
-
-  const handleLoadPreset = useCallback(
-    (gradeNum: number) => {
-      const preset = CURRICULUM_PRESETS[gradeNum]
-      if (!preset) return
-      const map: Record<
-        string,
-        { count: number; type: string; enabled: boolean }
-      > = {}
-      for (const item of preset) {
-        const subject = subjects.find((s) => s.name === item.subjectName)
-        if (subject) {
-          map[subject.id] = {
-            count: item.weeklyHours,
-            type: item.type ?? "normal",
-            enabled: true,
-          }
+      for (const item of items) {
+        for (let i = 0; i < targetClasses.length; i++) {
+          classAssignments.push({
+            komaIndex: komasData.length,
+            classId: targetClasses[i].id,
+          })
+          komasData.push({
+            subjectId: item.subjectId,
+            gradeId,
+            count: item.count,
+            type: item.type,
+          })
         }
       }
-      setBatchPreset(map)
+
+      const created = await batchCreateKomas(komasData)
+
+      // 各駒にクラスを割当
+      for (const assignment of classAssignments) {
+        const koma = created[assignment.komaIndex]
+        if (koma) {
+          await setKomaClasses(koma.id, [assignment.classId])
+        }
+      }
+
+      toast.success(`${items.length}教科 × ${targetClasses.length}クラスの駒を生成しました`)
     },
-    [subjects]
+    [classes, batchCreateKomas, setKomaClasses]
   )
 
-  const handleBatchGenerate = useCallback(async () => {
-    if (!batchGradeId) return
-    const grade = grades.find((g) => g.id === batchGradeId)
-    if (!grade) return
-
-    const komasToCreate = generateKomasFromPreset(
-      batchPreset,
-      batchGradeId,
-      subjects
-    )
-
-    if (komasToCreate.length === 0) {
-      toast.error("生成する駒がありません")
-      return
-    }
-
-    try {
-      await batchCreateKomas(komasToCreate)
-      setBatchDialogOpen(false)
-      toast.success(`${komasToCreate.length}件の駒を生成しました`)
-    } catch {
-      toast.error("一括生成に失敗しました")
-    }
-  }, [batchGradeId, batchPreset, grades, subjects, batchCreateKomas])
+  const handleDeleteAndGenerate = useCallback(
+    async (
+      gradeId: string,
+      items: { subjectId: string; count: number; type: string }[]
+    ) => {
+      await deleteKomasByGrade(gradeId)
+      await handlePresetGenerate(gradeId, items)
+    },
+    [deleteKomasByGrade, handlePresetGenerate]
+  )
 
   if (loading && grades.length === 0) {
     return (
@@ -306,16 +119,13 @@ export default function KomaPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <PageHeader title="駒設定" description="各学年の教科駒を設定します">
-        <div className="flex gap-2">
-          <Button variant="outline" onClick={() => setBatchDialogOpen(true)}>
-            一括生成
-          </Button>
-          <Button onClick={handleCreateKoma}>
-            <Plus className="mr-1 h-4 w-4" />
-            駒を追加
-          </Button>
-        </div>
+      <PageHeader
+        title="授業設定"
+        description="各学年の授業時数と担当先生を設定します"
+      >
+        <Button variant="outline" onClick={() => setPresetOpen(true)}>
+          プリセット読込
+        </Button>
       </PageHeader>
 
       {/* 学年タブ */}
@@ -338,570 +148,36 @@ export default function KomaPage() {
         </div>
       </div>
 
-      <div className="flex flex-1 overflow-hidden">
-        {/* 左: 駒リスト (教科グループ別) */}
-        <div className="w-64 border-r">
-          <ScrollArea className="h-full">
-            <div className="p-2">
-              {komasBySubject.map((group) => (
-                <div key={group.subject.id} className="mb-3">
-                  <div className="mb-1 flex items-center gap-1 px-2">
-                    <div
-                      className="h-2.5 w-2.5 rounded-full"
-                      style={{ backgroundColor: group.subject.color }}
-                    />
-                    <span className="text-xs font-semibold">
-                      {group.subject.name}
-                    </span>
-                    <Badge variant="secondary" className="ml-auto text-[10px]">
-                      {group.komas.reduce((sum, k) => sum + k.count, 0)}h
-                    </Badge>
-                  </div>
-                  {group.komas.map((koma) => (
-                    <button
-                      key={koma.id}
-                      type="button"
-                      className={`flex w-full items-center justify-between rounded-md px-3 py-1.5 text-left text-sm transition-colors ${
-                        selectedKomaId === koma.id
-                          ? "bg-accent font-medium"
-                          : "hover:bg-accent/50"
-                      }`}
-                      onClick={() => setSelectedKomaId(koma.id)}
-                    >
-                      <span className="truncate">
-                        {koma.label || group.subject.name}
-                        {koma.type === "consecutive" && (
-                          <span className="text-muted-foreground ml-1 text-[10px]">
-                            (連続)
-                          </span>
-                        )}
-                      </span>
-                      <span className="text-muted-foreground text-xs">
-                        {koma.count}h
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              ))}
-              {komas.length === 0 && (
-                <p className="text-muted-foreground py-4 text-center text-xs">
-                  駒がありません
-                </p>
-              )}
-            </div>
-          </ScrollArea>
-        </div>
-
-        {/* 右: 詳細 */}
-        <div className="flex-1 overflow-auto">
-          {selectedKoma ? (
-            <div className="p-6">
-              <div className="mb-4 flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleDuplicateKoma(selectedKoma)}
-                >
-                  <Copy className="mr-1 h-3 w-3" />
-                  コピー
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="text-destructive"
-                  onClick={() => handleDeleteKoma(selectedKoma)}
-                >
-                  <Trash2 className="mr-1 h-3 w-3" />
-                  削除
-                </Button>
-              </div>
-
-              <Tabs defaultValue="info">
-                <TabsList>
-                  <TabsTrigger value="info">基本情報</TabsTrigger>
-                  <TabsTrigger value="teachers">先生</TabsTrigger>
-                  <TabsTrigger value="classes">クラス</TabsTrigger>
-                  <TabsTrigger value="rooms">教室</TabsTrigger>
-                </TabsList>
-
-                <TabsContent value="info" className="mt-4 space-y-4">
-                  <Card>
-                    <CardContent className="space-y-4 pt-6">
-                      <div className="grid grid-cols-2 gap-4">
-                        <div className="space-y-2">
-                          <Label>科目</Label>
-                          <Select
-                            value={selectedKoma.subjectId}
-                            onValueChange={(v) =>
-                              handleUpdateField("subjectId", v)
-                            }
-                          >
-                            <SelectTrigger>
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {subjects.map((s) => (
-                                <SelectItem key={s.id} value={s.id}>
-                                  {s.name}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                        <div className="space-y-2">
-                          <Label>種類</Label>
-                          <RadioGroup
-                            value={selectedKoma.type}
-                            onValueChange={(v) => handleUpdateField("type", v)}
-                            className="flex gap-4"
-                          >
-                            {Object.entries(KOMA_TYPES).map(
-                              ([value, label]) => (
-                                <div
-                                  key={value}
-                                  className="flex items-center gap-1.5"
-                                >
-                                  <RadioGroupItem
-                                    value={value}
-                                    id={`type-${value}`}
-                                  />
-                                  <Label htmlFor={`type-${value}`}>
-                                    {label}
-                                  </Label>
-                                </div>
-                              )
-                            )}
-                          </RadioGroup>
-                        </div>
-                      </div>
-                      <div className="grid grid-cols-3 gap-4">
-                        <div className="space-y-2">
-                          <Label>駒数 (週)</Label>
-                          <Input
-                            key={selectedKoma.id + "-count"}
-                            type="number"
-                            min={0}
-                            max={10}
-                            defaultValue={selectedKoma.count}
-                            onBlur={(e) =>
-                              handleUpdateField(
-                                "count",
-                                parseInt(e.target.value) || 1
-                              )
-                            }
-                          />
-                        </div>
-                        <div className="space-y-2">
-                          <Label>優先順位 (0-9)</Label>
-                          <Input
-                            key={selectedKoma.id + "-priority"}
-                            type="number"
-                            min={0}
-                            max={9}
-                            defaultValue={selectedKoma.priority}
-                            onBlur={(e) =>
-                              handleUpdateField(
-                                "priority",
-                                parseInt(e.target.value) || 5
-                              )
-                            }
-                          />
-                        </div>
-                        <div className="space-y-2">
-                          <Label>ラベル</Label>
-                          <Input
-                            key={selectedKoma.id + "-label"}
-                            defaultValue={selectedKoma.label}
-                            onBlur={(e) =>
-                              handleUpdateField("label", e.target.value)
-                            }
-                            placeholder="任意"
-                          />
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-
-                <TabsContent value="teachers" className="mt-4">
-                  <Card>
-                    <CardHeader>
-                      <CardTitle>担当先生</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <div className="space-y-2">
-                        {teachers.map((teacher) => {
-                          const kt = selectedKoma.komaTeachers?.find(
-                            (kt) => kt.teacherId === teacher.id
-                          )
-                          const isAssigned = !!kt
-                          return (
-                            <div
-                              key={teacher.id}
-                              className="flex items-center gap-3"
-                            >
-                              <Checkbox
-                                id={`koma-teacher-${teacher.id}`}
-                                checked={isAssigned}
-                                onCheckedChange={(checked) =>
-                                  handleTeacherToggle(
-                                    teacher.id,
-                                    checked === true
-                                  )
-                                }
-                              />
-                              <Label
-                                htmlFor={`koma-teacher-${teacher.id}`}
-                                className="flex-1 cursor-pointer"
-                              >
-                                {teacher.name}
-                              </Label>
-                              {isAssigned && (
-                                <Select
-                                  value={kt.role}
-                                  onValueChange={(v) =>
-                                    handleTeacherRoleChange(teacher.id, v)
-                                  }
-                                >
-                                  <SelectTrigger className="w-20">
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    {Object.entries(KOMA_TEACHER_ROLES).map(
-                                      ([value, label]) => (
-                                        <SelectItem key={value} value={value}>
-                                          {label}
-                                        </SelectItem>
-                                      )
-                                    )}
-                                  </SelectContent>
-                                </Select>
-                              )}
-                            </div>
-                          )
-                        })}
-                        {teachers.length === 0 && (
-                          <p className="text-muted-foreground text-sm">
-                            先生が登録されていません
-                          </p>
-                        )}
-                      </div>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-
-                <TabsContent value="classes" className="mt-4">
-                  <Card>
-                    <CardHeader>
-                      <CardTitle>対象クラス</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <div className="space-y-2">
-                        {gradeClasses.map((cls) => {
-                          const isAssigned =
-                            selectedKoma.komaClasses?.some(
-                              (kc) => kc.classId === cls.id
-                            ) ?? false
-                          return (
-                            <div
-                              key={cls.id}
-                              className="flex items-center gap-2"
-                            >
-                              <Checkbox
-                                id={`koma-class-${cls.id}`}
-                                checked={isAssigned}
-                                onCheckedChange={(checked) =>
-                                  handleClassToggle(cls.id, checked === true)
-                                }
-                              />
-                              <Label
-                                htmlFor={`koma-class-${cls.id}`}
-                                className="cursor-pointer"
-                              >
-                                {cls.name}
-                              </Label>
-                            </div>
-                          )
-                        })}
-                        {gradeClasses.length === 0 && (
-                          <p className="text-muted-foreground text-sm">
-                            この学年にクラスがありません
-                          </p>
-                        )}
-                      </div>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-
-                <TabsContent value="rooms" className="mt-4">
-                  <Card>
-                    <CardHeader>
-                      <CardTitle>使用教室</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <div className="space-y-2">
-                        {rooms.map((room) => {
-                          const isAssigned =
-                            selectedKoma.komaRooms?.some(
-                              (kr) => kr.roomId === room.id
-                            ) ?? false
-                          return (
-                            <div
-                              key={room.id}
-                              className="flex items-center gap-2"
-                            >
-                              <Checkbox
-                                id={`koma-room-${room.id}`}
-                                checked={isAssigned}
-                                onCheckedChange={(checked) =>
-                                  handleRoomToggle(room.id, checked === true)
-                                }
-                              />
-                              <Label
-                                htmlFor={`koma-room-${room.id}`}
-                                className="cursor-pointer"
-                              >
-                                {room.name}
-                              </Label>
-                            </div>
-                          )
-                        })}
-                        {rooms.length === 0 && (
-                          <p className="text-muted-foreground text-sm">
-                            特別教室が登録されていません
-                          </p>
-                        )}
-                      </div>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-              </Tabs>
-            </div>
-          ) : (
-            <div className="flex h-full items-center justify-center">
-              <p className="text-muted-foreground">
-                {komas.length > 0
-                  ? "左のリストから駒を選択してください"
-                  : "「駒を追加」または「一括生成」で駒を作成してください"}
-              </p>
-            </div>
-          )}
-        </div>
+      {/* メインテーブル */}
+      <div className="flex-1 overflow-auto p-6">
+        {selectedGradeId && (
+          <LessonTable
+            gradeId={selectedGradeId}
+            komas={komas}
+            subjects={subjects}
+            gradeClasses={gradeClasses}
+            teachers={teachers}
+            rooms={rooms}
+            createKoma={createKoma}
+            updateKoma={updateKoma}
+            deleteKoma={deleteKoma}
+            setKomaTeachers={setKomaTeachers}
+            setKomaClasses={setKomaClasses}
+            setKomaRooms={setKomaRooms}
+            batchCreateKomas={batchCreateKomas}
+          />
+        )}
       </div>
 
-      {/* 一括生成ダイアログ */}
-      <BatchGenerateDialog
-        open={batchDialogOpen}
-        onOpenChange={setBatchDialogOpen}
+      {/* プリセットダイアログ */}
+      <PresetDialog
+        open={presetOpen}
+        onOpenChange={setPresetOpen}
         grades={grades}
         subjects={subjects}
-        batchGradeId={batchGradeId}
-        setBatchGradeId={setBatchGradeId}
-        batchPreset={batchPreset}
-        setBatchPreset={setBatchPreset}
-        onLoadPreset={handleLoadPreset}
-        onGenerate={handleBatchGenerate}
-        onDeleteExisting={deleteKomasByGrade}
+        onGenerate={handlePresetGenerate}
+        onDeleteAndGenerate={handleDeleteAndGenerate}
       />
-
-      {/* 新規駒ダイアログ */}
-      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>駒を追加</DialogTitle>
-          </DialogHeader>
-          <p className="text-muted-foreground text-sm">
-            選択中の学年に新しい駒を追加します。追加後に詳細を設定してください。
-          </p>
-          <div className="flex justify-end gap-2">
-            <Button
-              variant="outline"
-              onClick={() => setCreateDialogOpen(false)}
-            >
-              キャンセル
-            </Button>
-            <Button onClick={handleCreateKoma}>追加</Button>
-          </div>
-        </DialogContent>
-      </Dialog>
     </div>
-  )
-}
-
-// 一括生成ダイアログ
-function BatchGenerateDialog({
-  open,
-  onOpenChange,
-  grades,
-  subjects,
-  batchGradeId,
-  setBatchGradeId,
-  batchPreset,
-  setBatchPreset,
-  onLoadPreset,
-  onGenerate,
-  onDeleteExisting,
-}: {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  grades: Grade[]
-  subjects: { id: string; name: string }[]
-  batchGradeId: string
-  setBatchGradeId: (id: string) => void
-  batchPreset: Record<string, { count: number; type: string; enabled: boolean }>
-  setBatchPreset: (
-    preset: Record<string, { count: number; type: string; enabled: boolean }>
-  ) => void
-  onLoadPreset: (gradeNum: number) => void
-  onGenerate: () => void
-  onDeleteExisting: (gradeId: string) => Promise<void>
-}) {
-  const selectedGrade = grades.find((g) => g.id === batchGradeId)
-
-  const handleDeleteAndGenerate = useCallback(async () => {
-    if (batchGradeId) {
-      await onDeleteExisting(batchGradeId)
-    }
-    onGenerate()
-  }, [batchGradeId, onDeleteExisting, onGenerate])
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>駒の一括生成</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-4">
-          <div className="flex items-end gap-4">
-            <div className="flex-1 space-y-2">
-              <Label>対象学年</Label>
-              <Select value={batchGradeId} onValueChange={setBatchGradeId}>
-                <SelectTrigger>
-                  <SelectValue placeholder="学年を選択" />
-                </SelectTrigger>
-                <SelectContent>
-                  {grades.map((g) => (
-                    <SelectItem key={g.id} value={g.id}>
-                      {g.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <Button
-              variant="outline"
-              onClick={() => {
-                if (selectedGrade) onLoadPreset(selectedGrade.gradeNum)
-              }}
-              disabled={!selectedGrade}
-            >
-              プリセット読込
-            </Button>
-          </div>
-
-          {Object.keys(batchPreset).length > 0 && (
-            <div className="max-h-80 overflow-auto rounded border">
-              <table className="w-full text-sm">
-                <thead className="bg-muted sticky top-0">
-                  <tr>
-                    <th className="p-2 text-left">教科</th>
-                    <th className="w-20 p-2 text-center">週時間</th>
-                    <th className="w-24 p-2 text-center">種類</th>
-                    <th className="w-16 p-2 text-center">生成</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {subjects
-                    .filter((s) => batchPreset[s.id])
-                    .map((subject) => {
-                      const preset = batchPreset[subject.id]
-                      return (
-                        <tr key={subject.id} className="border-t">
-                          <td className="p-2">{subject.name}</td>
-                          <td className="p-2 text-center">
-                            <Input
-                              type="number"
-                              min={0}
-                              max={10}
-                              className="h-7 w-16 text-center"
-                              value={preset.count}
-                              onChange={(e) => {
-                                setBatchPreset({
-                                  ...batchPreset,
-                                  [subject.id]: {
-                                    ...preset,
-                                    count: parseInt(e.target.value) || 0,
-                                  },
-                                })
-                              }}
-                            />
-                          </td>
-                          <td className="p-2 text-center">
-                            <Select
-                              value={preset.type}
-                              onValueChange={(v) => {
-                                setBatchPreset({
-                                  ...batchPreset,
-                                  [subject.id]: { ...preset, type: v },
-                                })
-                              }}
-                            >
-                              <SelectTrigger className="h-7 w-20">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {Object.entries(KOMA_TYPES).map(
-                                  ([value, label]) => (
-                                    <SelectItem key={value} value={value}>
-                                      {label}
-                                    </SelectItem>
-                                  )
-                                )}
-                              </SelectContent>
-                            </Select>
-                          </td>
-                          <td className="p-2 text-center">
-                            <Checkbox
-                              checked={preset.enabled}
-                              onCheckedChange={(checked) => {
-                                setBatchPreset({
-                                  ...batchPreset,
-                                  [subject.id]: {
-                                    ...preset,
-                                    enabled: checked === true,
-                                  },
-                                })
-                              }}
-                            />
-                          </td>
-                        </tr>
-                      )
-                    })}
-                </tbody>
-              </table>
-            </div>
-          )}
-
-          <div className="flex justify-end gap-2">
-            <Button variant="outline" onClick={() => onOpenChange(false)}>
-              キャンセル
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteAndGenerate}
-              disabled={!batchGradeId || Object.keys(batchPreset).length === 0}
-            >
-              既存を削除して生成
-            </Button>
-            <Button
-              onClick={onGenerate}
-              disabled={!batchGradeId || Object.keys(batchPreset).length === 0}
-            >
-              追加生成
-            </Button>
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -98,8 +98,8 @@ const navCards: NavCard[] = [
     step: 7,
   },
   {
-    title: "駒設定",
-    description: "各学年の教科駒を設定・一括生成します",
+    title: "授業設定",
+    description: "各学年の授業時数と担当先生を設定します",
     href: "/data/koma",
     icon: <Puzzle className="h-6 w-6" />,
     section: "data",

--- a/app/scheduler/conditions/page.tsx
+++ b/app/scheduler/conditions/page.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react"
 import { toast } from "sonner"
 
 import { ConditionTable } from "@/components/scheduler/ConditionTable"
-import { PerSubjectDialog } from "@/components/scheduler/PerSubjectDialog"
+import { PerSubjectSection } from "@/components/scheduler/PerSubjectSection"
 import {
   Card,
   CardContent,
@@ -73,28 +73,37 @@ export default function ConditionsPage() {
         </p>
       </div>
 
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div>
-              <CardTitle>制約条件一覧</CardTitle>
-              <CardDescription>
-                各制約のレベル（禁止/考慮/無視）と重み（0-100）を設定してください
-              </CardDescription>
-            </div>
-            <PerSubjectDialog
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>制約条件一覧</CardTitle>
+            <CardDescription>
+              各制約のレベル（禁止/考慮/無視）と重みを設定してください
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ConditionTable condition={condition} onUpdate={handleUpdate} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>教科別条件</CardTitle>
+            <CardDescription>
+              教科ごとの配置制限と1日あたりの最大コマ数を設定します
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <PerSubjectSection
               conditionId={condition.id}
               subjects={subjects}
               perSubjectConditions={condition.perSubjectConditions ?? []}
               onUpsert={upsertPerSubject}
               onDelete={deletePerSubject}
             />
-          </div>
-        </CardHeader>
-        <CardContent>
-          <ConditionTable condition={condition} onUpdate={handleUpdate} />
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   )
 }

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -60,9 +60,9 @@ const setupItems: NavItem[] = [
 
 const dataItems: NavItem[] = [
   {
-    label: "先生設定",
-    href: "/data/teachers",
-    icon: <Users className="h-4 w-4" />,
+    label: "授業設定",
+    href: "/data/koma",
+    icon: <Puzzle className="h-4 w-4" />,
   },
   {
     label: "クラス設定",
@@ -80,9 +80,9 @@ const dataItems: NavItem[] = [
     icon: <Briefcase className="h-4 w-4" />,
   },
   {
-    label: "駒設定",
-    href: "/data/koma",
-    icon: <Puzzle className="h-4 w-4" />,
+    label: "先生設定",
+    href: "/data/teachers",
+    icon: <Users className="h-4 w-4" />,
   },
 ]
 

--- a/components/lesson/KomaDetailDialog.tsx
+++ b/components/lesson/KomaDetailDialog.tsx
@@ -1,0 +1,169 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { KOMA_TYPES } from "@/lib/constants"
+import type { Koma, SpecialRoom } from "@/types/common.types"
+
+interface KomaDetailDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  koma: Koma | null
+  rooms: SpecialRoom[]
+  onUpdateKoma: (id: string, data: Record<string, unknown>) => Promise<void>
+  onSetRooms: (komaId: string, roomIds: string[]) => Promise<void>
+}
+
+export function KomaDetailDialog({
+  open,
+  onOpenChange,
+  koma,
+  rooms,
+  onUpdateKoma,
+  onSetRooms,
+}: KomaDetailDialogProps) {
+  const [type, setType] = useState("normal")
+  const [priority, setPriority] = useState(5)
+  const [label, setLabel] = useState("")
+  const [roomIds, setRoomIds] = useState<Set<string>>(new Set())
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (open && koma) {
+      setType(koma.type)
+      setPriority(koma.priority)
+      setLabel(koma.label)
+      setRoomIds(new Set(koma.komaRooms?.map((kr) => kr.roomId) ?? []))
+    }
+  }, [open, koma])
+
+  const handleRoomToggle = useCallback(
+    (roomId: string, checked: boolean) => {
+      setRoomIds((prev) => {
+        const next = new Set(prev)
+        if (checked) {
+          next.add(roomId)
+        } else {
+          next.delete(roomId)
+        }
+        return next
+      })
+    },
+    []
+  )
+
+  const handleSave = useCallback(async () => {
+    if (!koma) return
+    setSaving(true)
+    try {
+      await onUpdateKoma(koma.id, { type, priority, label })
+      await onSetRooms(koma.id, Array.from(roomIds))
+      onOpenChange(false)
+    } finally {
+      setSaving(false)
+    }
+  }, [koma, type, priority, label, roomIds, onUpdateKoma, onSetRooms, onOpenChange])
+
+  if (!koma) return null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>詳細設定</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label className="text-xs font-semibold">種類</Label>
+            <RadioGroup
+              value={type}
+              onValueChange={setType}
+              className="flex gap-4"
+            >
+              {Object.entries(KOMA_TYPES).map(([value, name]) => (
+                <div key={value} className="flex items-center gap-1.5">
+                  <RadioGroupItem value={value} id={`detail-type-${value}`} />
+                  <Label htmlFor={`detail-type-${value}`} className="text-sm">
+                    {name}
+                  </Label>
+                </div>
+              ))}
+            </RadioGroup>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold">優先順位 (0-9)</Label>
+              <Input
+                type="number"
+                min={0}
+                max={9}
+                value={priority}
+                onChange={(e) =>
+                  setPriority(parseInt(e.target.value) || 5)
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold">ラベル</Label>
+              <Input
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="任意"
+              />
+            </div>
+          </div>
+
+          {rooms.length > 0 && (
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold">使用教室</Label>
+              <div className="space-y-1">
+                {rooms.map((room) => (
+                  <div key={room.id} className="flex items-center gap-2">
+                    <Checkbox
+                      id={`detail-room-${room.id}`}
+                      checked={roomIds.has(room.id)}
+                      onCheckedChange={(checked) =>
+                        handleRoomToggle(room.id, checked === true)
+                      }
+                    />
+                    <Label
+                      htmlFor={`detail-room-${room.id}`}
+                      className="cursor-pointer text-sm"
+                    >
+                      {room.name}
+                    </Label>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+            >
+              キャンセル
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={saving}>
+              保存
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/lesson/LessonTable.tsx
+++ b/components/lesson/LessonTable.tsx
@@ -1,0 +1,637 @@
+"use client"
+
+import { Plus, Trash2 } from "lucide-react"
+import { useCallback, useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import { KomaDetailDialog } from "@/components/lesson/KomaDetailDialog"
+import { TeacherCell } from "@/components/lesson/TeacherCell"
+import { TeacherSelectDialog } from "@/components/lesson/TeacherSelectDialog"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { buildSubjectRows } from "@/lib/lessonGrid"
+import type { CellData } from "@/lib/lessonGrid"
+import type {
+  ClassInfo,
+  Koma,
+  SpecialRoom,
+  Subject,
+  Teacher,
+} from "@/types/common.types"
+
+interface LessonTableProps {
+  gradeId: string
+  komas: Koma[]
+  subjects: Subject[]
+  gradeClasses: ClassInfo[]
+  teachers: Teacher[]
+  rooms: SpecialRoom[]
+  createKoma: (data: Record<string, unknown>) => Promise<Koma>
+  updateKoma: (id: string, data: Record<string, unknown>) => Promise<Koma>
+  deleteKoma: (id: string) => Promise<void>
+  setKomaTeachers: (
+    komaId: string,
+    teachers: { teacherId: string; role: string }[]
+  ) => Promise<void>
+  setKomaClasses: (komaId: string, classIds: string[]) => Promise<void>
+  setKomaRooms: (komaId: string, roomIds: string[]) => Promise<void>
+  batchCreateKomas: (data: Record<string, unknown>[]) => Promise<Koma[]>
+}
+
+export function LessonTable({
+  gradeId,
+  komas,
+  subjects,
+  gradeClasses,
+  teachers,
+  rooms,
+  createKoma,
+  updateKoma,
+  deleteKoma,
+  setKomaTeachers,
+  setKomaClasses,
+  setKomaRooms,
+  batchCreateKomas,
+}: LessonTableProps) {
+  // ダイアログ状態
+  const [teacherDialogKomaId, setTeacherDialogKomaId] = useState<
+    string | null
+  >(null)
+  const [detailDialogKomaId, setDetailDialogKomaId] = useState<string | null>(
+    null
+  )
+  const [combineDialogKomaId, setCombineDialogKomaId] = useState<
+    string | null
+  >(null)
+  const [addSubjectDialogOpen, setAddSubjectDialogOpen] = useState(false)
+
+  // グリッドモデル計算
+  const rows = useMemo(
+    () => buildSubjectRows(komas, subjects, gradeClasses),
+    [komas, subjects, gradeClasses]
+  )
+
+  // 表に含まれていない教科
+  const unusedSubjects = useMemo(() => {
+    const usedIds = new Set(rows.map((r) => r.subjectId))
+    return subjects.filter(
+      (s) => !usedIds.has(s.id) && s.category === "general"
+    )
+  }, [rows, subjects])
+
+  // ダイアログ用の駒データ
+  const teacherDialogKoma = komas.find((k) => k.id === teacherDialogKomaId)
+  const detailDialogKoma = komas.find((k) => k.id === detailDialogKomaId)
+
+  // === 時数変更 ===
+  const handleHoursChange = useCallback(
+    async (subjectId: string, newHours: number) => {
+      const row = rows.find((r) => r.subjectId === subjectId)
+      if (!row) return
+
+      if (newHours <= 0) {
+        // 全削除
+        for (const komaId of row.komaIds) {
+          await deleteKoma(komaId)
+        }
+        toast.success("教科を削除しました")
+        return
+      }
+
+      if (row.komaIds.length === 0) {
+        // 新規作成: クラス数分の駒を生成
+        await createKomasForSubject(subjectId, newHours)
+        return
+      }
+
+      // 既存駒のcountを更新
+      for (const komaId of row.komaIds) {
+        await updateKoma(komaId, { count: newHours })
+      }
+    },
+    [rows, deleteKoma, updateKoma]
+  )
+
+  // 教科追加時の駒生成
+  const createKomasForSubject = useCallback(
+    async (subjectId: string, count: number) => {
+      if (gradeClasses.length === 0) return
+
+      // クラス数分の駒を一括作成
+      const komasData = gradeClasses.map(() => ({
+        subjectId,
+        gradeId,
+        count,
+      }))
+      const created = await batchCreateKomas(komasData)
+
+      // 各駒にクラスを割当
+      for (let i = 0; i < created.length; i++) {
+        if (gradeClasses[i]) {
+          await setKomaClasses(created[i].id, [gradeClasses[i].id])
+        }
+      }
+    },
+    [gradeId, gradeClasses, batchCreateKomas, setKomaClasses]
+  )
+
+  // === 教科追加 ===
+  const handleAddSubject = useCallback(
+    async (subjectId: string) => {
+      await createKomasForSubject(subjectId, 1)
+      setAddSubjectDialogOpen(false)
+      toast.success("教科を追加しました")
+    },
+    [createKomasForSubject]
+  )
+
+  // === 先生設定保存 ===
+  const handleSaveTeachers = useCallback(
+    async (teacherAssignments: { teacherId: string; role: string }[]) => {
+      if (!teacherDialogKomaId) return
+      await setKomaTeachers(teacherDialogKomaId, teacherAssignments)
+    },
+    [teacherDialogKomaId, setKomaTeachers]
+  )
+
+  // === 詳細設定保存 ===
+  const handleUpdateKoma = useCallback(
+    async (id: string, data: Record<string, unknown>) => {
+      await updateKoma(id, data)
+    },
+    [updateKoma]
+  )
+
+  const handleSetRooms = useCallback(
+    async (komaId: string, roomIds: string[]) => {
+      await setKomaRooms(komaId, roomIds)
+    },
+    [setKomaRooms]
+  )
+
+  // === 合同授業設定 ===
+  const handleCombineClasses = useCallback(
+    async (komaId: string, targetClassIds: string[]) => {
+      // 対象の駒を特定
+      const sourceKoma = komas.find((k) => k.id === komaId)
+      if (!sourceKoma) return
+
+      // 同じ教科の他の駒から、指定クラスに割当済みの駒を見つける
+      const sameSubjectKomas = komas.filter(
+        (k) => k.subjectId === sourceKoma.subjectId && k.id !== komaId
+      )
+      const komaIdsToDelete: string[] = []
+
+      for (const targetClassId of targetClassIds) {
+        const targetKoma = sameSubjectKomas.find(
+          (k) =>
+            k.komaClasses?.some((kc) => kc.classId === targetClassId) ?? false
+        )
+        if (targetKoma && !komaIdsToDelete.includes(targetKoma.id)) {
+          komaIdsToDelete.push(targetKoma.id)
+        }
+      }
+
+      // 元の駒に全クラスを割当
+      const sourceClassIds =
+        sourceKoma.komaClasses?.map((kc) => kc.classId) ?? []
+      const allClassIds = [...new Set([...sourceClassIds, ...targetClassIds])]
+      await setKomaClasses(komaId, allClassIds)
+
+      // 統合された駒を削除
+      for (const id of komaIdsToDelete) {
+        await deleteKoma(id)
+      }
+
+      setCombineDialogKomaId(null)
+      toast.success("合同授業を設定しました")
+    },
+    [komas, setKomaClasses, deleteKoma]
+  )
+
+  // === 合同授業解除 ===
+  const handleSplitCombine = useCallback(
+    async (komaId: string) => {
+      const koma = komas.find((k) => k.id === komaId)
+      if (!koma) return
+
+      const classIds = koma.komaClasses?.map((kc) => kc.classId) ?? []
+      if (classIds.length <= 1) return
+
+      const teacherData =
+        koma.komaTeachers?.map((kt) => ({
+          teacherId: kt.teacherId,
+          role: kt.role,
+        })) ?? []
+
+      // 最初のクラスだけ元の駒に残す
+      await setKomaClasses(komaId, [classIds[0]])
+
+      // 残りのクラスに新しい駒を作成
+      for (let i = 1; i < classIds.length; i++) {
+        const created = await createKoma({
+          subjectId: koma.subjectId,
+          gradeId: koma.gradeId,
+          count: koma.count,
+          type: koma.type,
+          priority: koma.priority,
+          label: koma.label,
+        })
+        await setKomaClasses(created.id, [classIds[i]])
+        if (teacherData.length > 0) {
+          await setKomaTeachers(created.id, teacherData)
+        }
+      }
+
+      toast.success("合同授業を解除しました")
+    },
+    [komas, setKomaClasses, createKoma, setKomaTeachers]
+  )
+
+  // 先生ダイアログ用の現在値
+  const currentMainId =
+    teacherDialogKoma?.komaTeachers?.find((kt) => kt.role === "main")
+      ?.teacherId ?? null
+  const currentSubIds =
+    teacherDialogKoma?.komaTeachers
+      ?.filter((kt) => kt.role === "sub")
+      .map((kt) => kt.teacherId) ?? []
+
+  if (gradeClasses.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p className="text-muted-foreground">
+          この学年にクラスがありません。初期設定で学校を設定してください。
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="overflow-auto">
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="bg-muted/50">
+              <th className="border px-3 py-2 text-left font-medium">教科</th>
+              <th className="w-16 border px-2 py-2 text-center font-medium">
+                時数
+              </th>
+              {gradeClasses.map((cls) => (
+                <th
+                  key={cls.id}
+                  className="min-w-[100px] border px-3 py-2 text-center font-medium"
+                >
+                  {cls.name}
+                </th>
+              ))}
+              <th className="w-10 border px-1 py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <SubjectRowView
+                key={row.subjectId}
+                row={row}
+                gradeClasses={gradeClasses}
+                onHoursChange={handleHoursChange}
+                onClickTeacher={setTeacherDialogKomaId}
+                onCombine={setCombineDialogKomaId}
+                onSplitCombine={handleSplitCombine}
+                onDetail={setDetailDialogKomaId}
+                onDeleteSubject={async () => {
+                  for (const komaId of row.komaIds) {
+                    await deleteKoma(komaId)
+                  }
+                  toast.success("教科を削除しました")
+                }}
+              />
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={gradeClasses.length + 3}
+                  className="text-muted-foreground border py-8 text-center"
+                >
+                  授業がありません。「+ 教科を追加」またはプリセットから生成してください。
+                </td>
+              </tr>
+            )}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colSpan={gradeClasses.length + 3} className="border px-3 py-1">
+                {unusedSubjects.length > 0 ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-muted-foreground h-7 text-xs"
+                    onClick={() => setAddSubjectDialogOpen(true)}
+                  >
+                    <Plus className="mr-1 h-3 w-3" />
+                    教科を追加
+                  </Button>
+                ) : (
+                  <span className="text-muted-foreground px-2 text-xs">
+                    全教科が設定済みです
+                  </span>
+                )}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      {/* 先生選択ダイアログ */}
+      <TeacherSelectDialog
+        open={!!teacherDialogKomaId}
+        onOpenChange={(open) => {
+          if (!open) setTeacherDialogKomaId(null)
+        }}
+        teachers={teachers}
+        currentMainId={currentMainId}
+        currentSubIds={currentSubIds}
+        onSave={handleSaveTeachers}
+      />
+
+      {/* 詳細設定ダイアログ */}
+      <KomaDetailDialog
+        open={!!detailDialogKomaId}
+        onOpenChange={(open) => {
+          if (!open) setDetailDialogKomaId(null)
+        }}
+        koma={detailDialogKoma ?? null}
+        rooms={rooms}
+        onUpdateKoma={handleUpdateKoma}
+        onSetRooms={handleSetRooms}
+      />
+
+      {/* 合同授業設定ダイアログ */}
+      <CombineDialog
+        open={!!combineDialogKomaId}
+        onOpenChange={(open) => {
+          if (!open) setCombineDialogKomaId(null)
+        }}
+        komaId={combineDialogKomaId}
+        komas={komas}
+        gradeClasses={gradeClasses}
+        onCombine={handleCombineClasses}
+      />
+
+      {/* 教科追加ダイアログ */}
+      <Dialog open={addSubjectDialogOpen} onOpenChange={setAddSubjectDialogOpen}>
+        <DialogContent className="max-w-xs">
+          <DialogHeader>
+            <DialogTitle>教科を追加</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            {unusedSubjects.map((s) => (
+              <Button
+                key={s.id}
+                variant="outline"
+                className="w-full justify-start"
+                onClick={() => handleAddSubject(s.id)}
+              >
+                <div
+                  className="mr-2 h-3 w-3 rounded-full"
+                  style={{ backgroundColor: s.color }}
+                />
+                {s.name}
+              </Button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+// === 教科行コンポーネント ===
+
+function SubjectRowView({
+  row,
+  gradeClasses,
+  onHoursChange,
+  onClickTeacher,
+  onCombine,
+  onSplitCombine,
+  onDetail,
+  onDeleteSubject,
+}: {
+  row: ReturnType<typeof buildSubjectRows>[number]
+  gradeClasses: ClassInfo[]
+  onHoursChange: (subjectId: string, hours: number) => Promise<void>
+  onClickTeacher: (komaId: string) => void
+  onCombine: (komaId: string) => void
+  onSplitCombine: (komaId: string) => Promise<void>
+  onDetail: (komaId: string) => void
+  onDeleteSubject: () => Promise<void>
+}) {
+  return (
+    <tr>
+      {/* 教科名 */}
+      <td className="border px-3 py-1">
+        <div className="flex items-center gap-2">
+          <div
+            className="h-3 w-3 shrink-0 rounded-full"
+            style={{ backgroundColor: row.subjectColor }}
+          />
+          <span className="font-medium">{row.subjectName}</span>
+        </div>
+      </td>
+
+      {/* 時数 */}
+      <td className="border px-1 py-1 text-center">
+        <Input
+          type="number"
+          min={0}
+          max={10}
+          defaultValue={row.hours}
+          key={`${row.subjectId}-${row.hours}`}
+          className="h-7 w-14 text-center"
+          onBlur={(e) => {
+            const val = parseInt(e.target.value) || 0
+            if (val !== row.hours) {
+              onHoursChange(row.subjectId, val)
+            }
+          }}
+        />
+      </td>
+
+      {/* クラス列 */}
+      {row.cells.map((cell, colIdx) => {
+        if (cell === "spanned") return null
+        if (cell === null) {
+          return (
+            <td key={colIdx} className="border px-2 py-1">
+              <span className="text-muted-foreground text-xs">-</span>
+            </td>
+          )
+        }
+
+        const isCombined = cell.classIds.length > 1
+        const combinedClassNames = isCombined
+          ? cell.classIds
+              .map((cid) => gradeClasses.find((c) => c.id === cid)?.name)
+              .filter(Boolean)
+              .join("+")
+          : undefined
+
+        return (
+          <TeacherCell
+            key={cell.komaId}
+            cell={cell}
+            colSpan={cell.colSpan}
+            subjectColor={row.subjectColor}
+            isCombined={isCombined}
+            combinedClassNames={combinedClassNames}
+            onClickTeacher={onClickTeacher}
+            onCombine={onCombine}
+            onSplitCombine={onSplitCombine}
+            onDetail={onDetail}
+          />
+        )
+      })}
+
+      {/* 削除 */}
+      <td className="border px-1 py-1 text-center">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-destructive h-6 w-6 p-0"
+          onClick={onDeleteSubject}
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </td>
+    </tr>
+  )
+}
+
+// === 合同授業設定ダイアログ ===
+
+function CombineDialog({
+  open,
+  onOpenChange,
+  komaId,
+  komas,
+  gradeClasses,
+  onCombine,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  komaId: string | null
+  komas: Koma[]
+  gradeClasses: ClassInfo[]
+  onCombine: (komaId: string, classIds: string[]) => Promise<void>
+}) {
+  const [selectedClassIds, setSelectedClassIds] = useState<Set<string>>(
+    new Set()
+  )
+  const [saving, setSaving] = useState(false)
+
+  const koma = komas.find((k) => k.id === komaId)
+  const currentClassIds = koma?.komaClasses?.map((kc) => kc.classId) ?? []
+
+  // この駒が属していないクラスを選択肢として表示
+  const availableClasses = gradeClasses.filter(
+    (c) => !currentClassIds.includes(c.id)
+  )
+
+  const handleToggle = useCallback(
+    (classId: string, checked: boolean) => {
+      setSelectedClassIds((prev) => {
+        const next = new Set(prev)
+        if (checked) {
+          next.add(classId)
+        } else {
+          next.delete(classId)
+        }
+        return next
+      })
+    },
+    []
+  )
+
+  const handleSave = useCallback(async () => {
+    if (!komaId || selectedClassIds.size === 0) return
+    setSaving(true)
+    try {
+      await onCombine(komaId, Array.from(selectedClassIds))
+      setSelectedClassIds(new Set())
+    } finally {
+      setSaving(false)
+    }
+  }, [komaId, selectedClassIds, onCombine])
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) setSelectedClassIds(new Set())
+        onOpenChange(v)
+      }}
+    >
+      <DialogContent className="max-w-xs">
+        <DialogHeader>
+          <DialogTitle>合同授業の設定</DialogTitle>
+        </DialogHeader>
+        <p className="text-muted-foreground text-sm">
+          合同にするクラスを選択してください。
+        </p>
+        <div className="space-y-2">
+          {availableClasses.map((cls) => (
+            <div key={cls.id} className="flex items-center gap-2">
+              <Checkbox
+                id={`combine-${cls.id}`}
+                checked={selectedClassIds.has(cls.id)}
+                onCheckedChange={(checked) =>
+                  handleToggle(cls.id, checked === true)
+                }
+              />
+              <Label htmlFor={`combine-${cls.id}`} className="cursor-pointer">
+                {cls.name}
+              </Label>
+            </div>
+          ))}
+          {availableClasses.length === 0 && (
+            <p className="text-muted-foreground text-sm">
+              合同にできるクラスがありません。
+            </p>
+          )}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+          >
+            キャンセル
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={selectedClassIds.size === 0 || saving}
+          >
+            設定
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/lesson/PresetDialog.tsx
+++ b/components/lesson/PresetDialog.tsx
@@ -1,0 +1,251 @@
+"use client"
+
+import { useCallback, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { KOMA_TYPES } from "@/lib/constants"
+import { CURRICULUM_PRESETS } from "@/lib/komaGenerator"
+import type { Grade, Subject } from "@/types/common.types"
+
+interface PresetDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  grades: Grade[]
+  subjects: Subject[]
+  onGenerate: (
+    gradeId: string,
+    items: { subjectId: string; count: number; type: string }[]
+  ) => Promise<void>
+  onDeleteAndGenerate: (
+    gradeId: string,
+    items: { subjectId: string; count: number; type: string }[]
+  ) => Promise<void>
+}
+
+interface PresetItem {
+  count: number
+  type: string
+  enabled: boolean
+}
+
+export function PresetDialog({
+  open,
+  onOpenChange,
+  grades,
+  subjects,
+  onGenerate,
+  onDeleteAndGenerate,
+}: PresetDialogProps) {
+  const [gradeId, setGradeId] = useState("")
+  const [preset, setPreset] = useState<Record<string, PresetItem>>({})
+  const [loading, setLoading] = useState(false)
+
+  const selectedGrade = grades.find((g) => g.id === gradeId)
+
+  const handleLoadPreset = useCallback(() => {
+    if (!selectedGrade) return
+    const items = CURRICULUM_PRESETS[selectedGrade.gradeNum]
+    if (!items) return
+
+    const map: Record<string, PresetItem> = {}
+    for (const item of items) {
+      const subject = subjects.find((s) => s.name === item.subjectName)
+      if (subject) {
+        map[subject.id] = {
+          count: item.weeklyHours,
+          type: item.type ?? "normal",
+          enabled: true,
+        }
+      }
+    }
+    setPreset(map)
+  }, [selectedGrade, subjects])
+
+  const buildItems = useCallback(() => {
+    return Object.entries(preset)
+      .filter(([, v]) => v.enabled && v.count > 0)
+      .map(([subjectId, v]) => ({
+        subjectId,
+        count: v.count,
+        type: v.type,
+      }))
+  }, [preset])
+
+  const handleGenerate = useCallback(async () => {
+    if (!gradeId) return
+    setLoading(true)
+    try {
+      await onGenerate(gradeId, buildItems())
+      onOpenChange(false)
+    } finally {
+      setLoading(false)
+    }
+  }, [gradeId, buildItems, onGenerate, onOpenChange])
+
+  const handleDeleteAndGenerate = useCallback(async () => {
+    if (!gradeId) return
+    setLoading(true)
+    try {
+      await onDeleteAndGenerate(gradeId, buildItems())
+      onOpenChange(false)
+    } finally {
+      setLoading(false)
+    }
+  }, [gradeId, buildItems, onDeleteAndGenerate, onOpenChange])
+
+  const hasItems = Object.keys(preset).length > 0
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>プリセットから一括生成</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="flex items-end gap-4">
+            <div className="flex-1 space-y-2">
+              <Label>対象学年</Label>
+              <Select value={gradeId} onValueChange={setGradeId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="学年を選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  {grades.map((g) => (
+                    <SelectItem key={g.id} value={g.id}>
+                      {g.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              variant="outline"
+              onClick={handleLoadPreset}
+              disabled={!selectedGrade}
+            >
+              プリセット読込
+            </Button>
+          </div>
+
+          {hasItems && (
+            <div className="max-h-80 overflow-auto rounded border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted sticky top-0">
+                  <tr>
+                    <th className="p-2 text-left">教科</th>
+                    <th className="w-20 p-2 text-center">週時間</th>
+                    <th className="w-24 p-2 text-center">種類</th>
+                    <th className="w-16 p-2 text-center">生成</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {subjects
+                    .filter((s) => preset[s.id])
+                    .map((subject) => {
+                      const item = preset[subject.id]
+                      return (
+                        <tr key={subject.id} className="border-t">
+                          <td className="p-2">{subject.name}</td>
+                          <td className="p-2 text-center">
+                            <Input
+                              type="number"
+                              min={0}
+                              max={10}
+                              className="h-7 w-16 text-center"
+                              value={item.count}
+                              onChange={(e) =>
+                                setPreset({
+                                  ...preset,
+                                  [subject.id]: {
+                                    ...item,
+                                    count: parseInt(e.target.value) || 0,
+                                  },
+                                })
+                              }
+                            />
+                          </td>
+                          <td className="p-2 text-center">
+                            <Select
+                              value={item.type}
+                              onValueChange={(v) =>
+                                setPreset({
+                                  ...preset,
+                                  [subject.id]: { ...item, type: v },
+                                })
+                              }
+                            >
+                              <SelectTrigger className="h-7 w-20">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {Object.entries(KOMA_TYPES).map(
+                                  ([value, label]) => (
+                                    <SelectItem key={value} value={value}>
+                                      {label}
+                                    </SelectItem>
+                                  )
+                                )}
+                              </SelectContent>
+                            </Select>
+                          </td>
+                          <td className="p-2 text-center">
+                            <Checkbox
+                              checked={item.enabled}
+                              onCheckedChange={(checked) =>
+                                setPreset({
+                                  ...preset,
+                                  [subject.id]: {
+                                    ...item,
+                                    enabled: checked === true,
+                                  },
+                                })
+                              }
+                            />
+                          </td>
+                        </tr>
+                      )
+                    })}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              キャンセル
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteAndGenerate}
+              disabled={!gradeId || !hasItems || loading}
+            >
+              既存を削除して生成
+            </Button>
+            <Button
+              onClick={handleGenerate}
+              disabled={!gradeId || !hasItems || loading}
+            >
+              追加生成
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/lesson/TeacherCell.tsx
+++ b/components/lesson/TeacherCell.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { Settings, UserPlus, Users, Unlink } from "lucide-react"
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
+import type { CellData } from "@/lib/lessonGrid"
+
+interface TeacherCellProps {
+  cell: CellData
+  colSpan: number
+  subjectColor: string
+  isCombined: boolean
+  combinedClassNames?: string
+  onClickTeacher: (komaId: string) => void
+  onCombine: (komaId: string) => void
+  onSplitCombine: (komaId: string) => void
+  onDetail: (komaId: string) => void
+}
+
+export function TeacherCell({
+  cell,
+  colSpan,
+  subjectColor,
+  isCombined,
+  combinedClassNames,
+  onClickTeacher,
+  onCombine,
+  onSplitCombine,
+  onDetail,
+}: TeacherCellProps) {
+  const mainTeacher = cell.teachers.find((t) => t.role === "main")
+  const subTeachers = cell.teachers.filter((t) => t.role === "sub")
+  const hasTeacher = cell.teachers.length > 0
+
+  return (
+    <td
+      colSpan={colSpan}
+      className="border p-0"
+      style={{ borderLeftColor: subjectColor, borderLeftWidth: colSpan > 1 ? 2 : undefined }}
+    >
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div
+            className="flex min-h-[2.5rem] cursor-pointer flex-col justify-center px-2 py-1 transition-colors hover:bg-accent/50"
+            onClick={() => onClickTeacher(cell.komaId)}
+          >
+            {hasTeacher ? (
+              <>
+                <span className="text-sm leading-tight">
+                  {mainTeacher?.name ?? ""}
+                  {subTeachers.length > 0 && (
+                    <span className="text-muted-foreground text-[10px]">
+                      {" "}(主)
+                    </span>
+                  )}
+                </span>
+                {subTeachers.map((t) => (
+                  <span
+                    key={t.teacherId}
+                    className="text-muted-foreground text-xs leading-tight"
+                  >
+                    {t.name} (副)
+                  </span>
+                ))}
+                {isCombined && combinedClassNames && (
+                  <span className="text-muted-foreground text-[10px] leading-tight">
+                    [{combinedClassNames}]
+                  </span>
+                )}
+              </>
+            ) : (
+              <span className="text-muted-foreground text-xs">
+                {isCombined && combinedClassNames
+                  ? `[${combinedClassNames}]`
+                  : "未設定"}
+              </span>
+            )}
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onClick={() => onClickTeacher(cell.komaId)}>
+            <UserPlus className="mr-2 h-3.5 w-3.5" />
+            担当先生を設定
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          {isCombined ? (
+            <ContextMenuItem onClick={() => onSplitCombine(cell.komaId)}>
+              <Unlink className="mr-2 h-3.5 w-3.5" />
+              合同授業を解除
+            </ContextMenuItem>
+          ) : (
+            <ContextMenuItem onClick={() => onCombine(cell.komaId)}>
+              <Users className="mr-2 h-3.5 w-3.5" />
+              合同授業に変更
+            </ContextMenuItem>
+          )}
+          <ContextMenuSeparator />
+          <ContextMenuItem onClick={() => onDetail(cell.komaId)}>
+            <Settings className="mr-2 h-3.5 w-3.5" />
+            詳細設定
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    </td>
+  )
+}

--- a/components/lesson/TeacherSelectDialog.tsx
+++ b/components/lesson/TeacherSelectDialog.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import type { Teacher } from "@/types/common.types"
+
+interface TeacherSelectDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  teachers: Teacher[]
+  currentMainId: string | null
+  currentSubIds: string[]
+  onSave: (
+    teachers: { teacherId: string; role: string }[]
+  ) => Promise<void>
+}
+
+export function TeacherSelectDialog({
+  open,
+  onOpenChange,
+  teachers,
+  currentMainId,
+  currentSubIds,
+  onSave,
+}: TeacherSelectDialogProps) {
+  const [mainId, setMainId] = useState<string>("none")
+  const [subIds, setSubIds] = useState<Set<string>>(new Set())
+  const [saving, setSaving] = useState(false)
+  const [search, setSearch] = useState("")
+
+  useEffect(() => {
+    if (open) {
+      setMainId(currentMainId ?? "none")
+      setSubIds(new Set(currentSubIds))
+      setSearch("")
+    }
+  }, [open, currentMainId, currentSubIds])
+
+  const filteredTeachers = useMemo(() => {
+    if (!search.trim()) return teachers
+    const q = search.trim().toLowerCase()
+    return teachers.filter(
+      (t) =>
+        t.name.toLowerCase().includes(q) ||
+        t.nameKana.toLowerCase().includes(q)
+    )
+  }, [teachers, search])
+
+  const handleSubToggle = useCallback((teacherId: string, checked: boolean) => {
+    setSubIds((prev) => {
+      const next = new Set(prev)
+      if (checked) {
+        next.add(teacherId)
+      } else {
+        next.delete(teacherId)
+      }
+      return next
+    })
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    try {
+      const result: { teacherId: string; role: string }[] = []
+      if (mainId !== "none") {
+        result.push({ teacherId: mainId, role: "main" })
+      }
+      for (const sid of subIds) {
+        if (sid !== mainId) {
+          result.push({ teacherId: sid, role: "sub" })
+        }
+      }
+      await onSave(result)
+      onOpenChange(false)
+    } finally {
+      setSaving(false)
+    }
+  }, [mainId, subIds, onSave, onOpenChange])
+
+  // 副担当の選択肢から主担当を除外
+  const subCandidates = filteredTeachers.filter((t) => t.id !== mainId)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm max-h-[80vh] overflow-auto">
+        <DialogHeader>
+          <DialogTitle>担当先生の設定</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Input
+            placeholder="先生を検索..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8"
+          />
+
+          <div className="space-y-2">
+            <Label className="text-xs font-semibold">
+              主担当（{filteredTeachers.length}人）
+            </Label>
+            <RadioGroup value={mainId} onValueChange={setMainId}>
+              {!search && (
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="none" id="main-none" />
+                  <Label
+                    htmlFor="main-none"
+                    className="text-muted-foreground cursor-pointer text-sm"
+                  >
+                    なし
+                  </Label>
+                </div>
+              )}
+              {filteredTeachers.map((t) => (
+                <div key={t.id} className="flex items-center gap-2">
+                  <RadioGroupItem value={t.id} id={`main-${t.id}`} />
+                  <Label
+                    htmlFor={`main-${t.id}`}
+                    className="cursor-pointer text-sm"
+                  >
+                    {t.name}
+                  </Label>
+                </div>
+              ))}
+            </RadioGroup>
+          </div>
+
+          {mainId !== "none" && (
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold">
+                副担当（共同授業）
+              </Label>
+              <div className="space-y-1">
+                {subCandidates.map((t) => (
+                  <div key={t.id} className="flex items-center gap-2">
+                    <Checkbox
+                      id={`sub-${t.id}`}
+                      checked={subIds.has(t.id)}
+                      onCheckedChange={(checked) =>
+                        handleSubToggle(t.id, checked === true)
+                      }
+                    />
+                    <Label
+                      htmlFor={`sub-${t.id}`}
+                      className="cursor-pointer text-sm"
+                    >
+                      {t.name}
+                    </Label>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+            >
+              キャンセル
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={saving}>
+              保存
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/scheduler/ConditionTable.tsx
+++ b/components/scheduler/ConditionTable.tsx
@@ -77,7 +77,7 @@ export function ConditionTable({ condition, onUpdate }: ConditionTableProps) {
           >
           const level = conditionRecord[field.key] as string
           const weight = conditionRecord[`${field.key}Weight`] as number
-          const isDisabled = level === "ignore"
+          const isConsider = level === "consider"
 
           return (
             <TableRow key={field.key}>
@@ -108,18 +108,27 @@ export function ConditionTable({ condition, onUpdate }: ConditionTableProps) {
               <TableCell>
                 {weight !== undefined && (
                   <div className="flex items-center gap-2">
-                    <Slider
-                      value={[weight]}
-                      min={0}
-                      max={100}
-                      step={5}
-                      disabled={isDisabled}
-                      onValueChange={(v) => handleWeightChange(field.key, v)}
-                      className="w-24"
-                    />
-                    <span className="text-muted-foreground w-8 text-xs">
-                      {weight}
-                    </span>
+                    {isConsider ? (
+                      <>
+                        <Slider
+                          value={[weight]}
+                          min={1}
+                          max={100}
+                          step={5}
+                          onValueChange={(v) =>
+                            handleWeightChange(field.key, v)
+                          }
+                          className="w-24"
+                        />
+                        <span className="text-muted-foreground w-8 text-xs">
+                          {weight}
+                        </span>
+                      </>
+                    ) : (
+                      <span className="text-muted-foreground text-xs">
+                        {level === "forbidden" ? "100000" : "0"}
+                      </span>
+                    )}
                   </div>
                 )}
               </TableCell>

--- a/components/scheduler/PerSubjectSection.tsx
+++ b/components/scheduler/PerSubjectSection.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { PLACEMENT_RESTRICTIONS } from "@/lib/constants"
+import type { PerSubjectCondition, Subject } from "@/types/common.types"
+
+const LEVEL_OPTIONS = {
+  forbidden: "禁止",
+  consider: "考慮",
+  ignore: "無視",
+} as const
+
+interface PerSubjectSectionProps {
+  conditionId: string
+  subjects: Subject[]
+  perSubjectConditions: PerSubjectCondition[]
+  onUpsert: (data: {
+    conditionId: string
+    subjectId: string
+    level?: string
+    placementRestriction?: string
+    maxPerDay?: number
+  }) => Promise<void>
+  onDelete: (conditionId: string, subjectId: string) => Promise<void>
+}
+
+export function PerSubjectSection({
+  conditionId,
+  subjects,
+  perSubjectConditions,
+  onUpsert,
+  onDelete,
+}: PerSubjectSectionProps) {
+  const getCondition = (subjectId: string) =>
+    perSubjectConditions.find((c) => c.subjectId === subjectId)
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>教科</TableHead>
+          <TableHead>レベル</TableHead>
+          <TableHead>配置制限</TableHead>
+          <TableHead>1日最大</TableHead>
+          <TableHead className="w-16"></TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {subjects
+          .filter((s) => s.category === "general")
+          .map((subject) => {
+            const cond = getCondition(subject.id)
+            const level = cond?.level ?? "consider"
+            const isIgnored = level === "ignore"
+            return (
+              <TableRow key={subject.id} className={isIgnored ? "opacity-40" : ""}>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <div
+                      className="h-3 w-3 rounded-full"
+                      style={{ backgroundColor: subject.color }}
+                    />
+                    {subject.name}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Select
+                    value={level}
+                    onValueChange={(v) =>
+                      onUpsert({
+                        conditionId,
+                        subjectId: subject.id,
+                        level: v,
+                        placementRestriction:
+                          cond?.placementRestriction ?? "any",
+                        maxPerDay: cond?.maxPerDay ?? 2,
+                      })
+                    }
+                  >
+                    <SelectTrigger className="h-8 w-20">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.entries(LEVEL_OPTIONS).map(([k, v]) => (
+                        <SelectItem key={k} value={k}>
+                          {v}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </TableCell>
+                <TableCell>
+                  <Select
+                    disabled={isIgnored}
+                    value={cond?.placementRestriction ?? "any"}
+                    onValueChange={(v) =>
+                      onUpsert({
+                        conditionId,
+                        subjectId: subject.id,
+                        level,
+                        placementRestriction: v,
+                        maxPerDay: cond?.maxPerDay ?? 2,
+                      })
+                    }
+                  >
+                    <SelectTrigger className="h-8 w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.entries(PLACEMENT_RESTRICTIONS).map(([k, v]) => (
+                        <SelectItem key={k} value={k}>
+                          {v}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </TableCell>
+                <TableCell>
+                  <Select
+                    disabled={isIgnored}
+                    value={String(cond?.maxPerDay ?? 2)}
+                    onValueChange={(v) =>
+                      onUpsert({
+                        conditionId,
+                        subjectId: subject.id,
+                        level,
+                        placementRestriction:
+                          cond?.placementRestriction ?? "any",
+                        maxPerDay: parseInt(v),
+                      })
+                    }
+                  >
+                    <SelectTrigger className="h-8 w-16">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[1, 2, 3, 4].map((n) => (
+                        <SelectItem key={n} value={String(n)}>
+                          {n}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </TableCell>
+                <TableCell>
+                  {cond && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onDelete(conditionId, subject.id)}
+                    >
+                      削除
+                    </Button>
+                  )}
+                </TableCell>
+              </TableRow>
+            )
+          })}
+      </TableBody>
+    </Table>
+  )
+}

--- a/components/scheduler/SolverProgress.tsx
+++ b/components/scheduler/SolverProgress.tsx
@@ -43,9 +43,9 @@ export function SolverProgressBar({
         <span>
           {progress?.placedCount ?? 0}/{progress?.totalKomas ?? 0} 駒配置
         </span>
-        <span>
-          違反: {progress?.violations ?? 0} | スコア: {progress?.score ?? 0}
-        </span>
+        {(progress?.score ?? 0) > 0 && (
+          <span>最良スコア: {(progress?.score ?? 0).toLocaleString()}</span>
+        )}
         <span>{((progress?.elapsedMs ?? 0) / 1000).toFixed(1)}秒</span>
       </div>
 

--- a/components/scheduler/SolverResultSummary.tsx
+++ b/components/scheduler/SolverResultSummary.tsx
@@ -65,6 +65,28 @@ export function SolverResultSummary({ result }: SolverResultSummaryProps) {
           )}
         </div>
       )}
+
+      {result.allPatternScores && result.allPatternScores.length > 1 && (
+        <div className="border-t pt-3">
+          <p className="text-muted-foreground mb-1 text-xs font-medium">
+            全{result.allPatternScores.length}パターンの結果
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {result.allPatternScores.map((p, i) => (
+              <Badge
+                key={i}
+                variant={
+                  i === result.selectedPatternIndex ? "default" : "outline"
+                }
+                className="text-xs"
+              >
+                #{p.index}: スコア{p.score} / 違反{p.violations}
+                {i === result.selectedPatternIndex && " (採用)"}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/electron-src/ipc-handlers/conditionHandlers.ts
+++ b/electron-src/ipc-handlers/conditionHandlers.ts
@@ -18,6 +18,7 @@ export function registerConditionHandlers() {
       data: {
         conditionId: string
         subjectId: string
+        level?: string
         placementRestriction?: string
         maxPerDay?: number
       }

--- a/electron-src/lib/prisma/condition.ts
+++ b/electron-src/lib/prisma/condition.ts
@@ -36,6 +36,7 @@ export async function upsertCondition(data: Record<string, unknown>) {
 export async function upsertPerSubjectCondition(data: {
   conditionId: string
   subjectId: string
+  level?: string
   placementRestriction?: string
   maxPerDay?: number
 }) {
@@ -53,6 +54,7 @@ export async function upsertPerSubjectCondition(data: {
       return await prisma.perSubjectCondition.update({
         where: { id: existing.id },
         data: {
+          level: data.level,
           placementRestriction: data.placementRestriction,
           maxPerDay: data.maxPerDay,
         },

--- a/lib/lessonGrid.ts
+++ b/lib/lessonGrid.ts
@@ -1,0 +1,178 @@
+import type { ClassInfo, Koma, Subject } from "@/types/common.types"
+
+export interface TeacherDisplay {
+  teacherId: string
+  name: string
+  role: "main" | "sub"
+}
+
+export interface CellData {
+  komaId: string
+  classIds: string[]
+  teachers: TeacherDisplay[]
+  colSpan: number
+}
+
+export interface SubjectRow {
+  subjectId: string
+  subjectName: string
+  subjectColor: string
+  hours: number
+  cells: (CellData | "spanned" | null)[]
+  komaIds: string[]
+}
+
+/**
+ * Koma[] をスプレッドシート用の SubjectRow[] に変換する。
+ * 各行 = 教科, 各セル = クラス列に対応する駒
+ */
+export function buildSubjectRows(
+  komas: Koma[],
+  subjects: Subject[],
+  gradeClasses: ClassInfo[]
+): SubjectRow[] {
+  // 教科別にグループ化
+  const groups = new Map<
+    string,
+    { subject: Subject; komas: Koma[] }
+  >()
+
+  for (const koma of komas) {
+    const existing = groups.get(koma.subjectId)
+    if (existing) {
+      existing.komas.push(koma)
+    } else {
+      const subject = subjects.find((s) => s.id === koma.subjectId) ??
+        koma.subject ?? {
+          id: koma.subjectId,
+          name: "不明",
+          shortName: "?",
+          color: "#999",
+          category: "general",
+          sortOrder: 999,
+          isDefault: false,
+          createdAt: "",
+          updatedAt: "",
+        }
+      groups.set(koma.subjectId, { subject, komas: [koma] })
+    }
+  }
+
+  const rows: SubjectRow[] = []
+
+  for (const [subjectId, group] of groups) {
+    const hours =
+      group.komas.length > 0 ? group.komas[0].count : 0
+
+    // クラスインデックス → CellData のマッピングを構築
+    // 1つの駒が複数クラスを持つ場合（合同授業）、最も左のクラスインデックスに配置
+    const classIndexToKoma = new Map<number, Koma>()
+
+    for (const koma of group.komas) {
+      const assignedClassIds =
+        koma.komaClasses?.map((kc) => kc.classId) ?? []
+
+      if (assignedClassIds.length === 0) {
+        // クラス未割当の駒 → 空きスロットに配置
+        for (let i = 0; i < gradeClasses.length; i++) {
+          if (!classIndexToKoma.has(i)) {
+            classIndexToKoma.set(i, koma)
+            break
+          }
+        }
+      } else {
+        // 割当済み → 該当クラスのインデックスにマッピング
+        const indices = assignedClassIds
+          .map((cid) => gradeClasses.findIndex((c) => c.id === cid))
+          .filter((i) => i >= 0)
+          .sort((a, b) => a - b)
+
+        if (indices.length > 0) {
+          // 最も左のインデックスに駒を紐付け
+          classIndexToKoma.set(indices[0], koma)
+          // 合同授業: 残りのインデックスもこの駒が占める（spanned にする）
+          for (let k = 1; k < indices.length; k++) {
+            classIndexToKoma.set(indices[k], koma)
+          }
+        }
+      }
+    }
+
+    // セル配列を構築
+    const cells: (CellData | "spanned" | null)[] = []
+    const seenKomaIds = new Set<string>()
+
+    for (let i = 0; i < gradeClasses.length; i++) {
+      const koma = classIndexToKoma.get(i)
+      if (!koma) {
+        cells.push(null)
+        continue
+      }
+
+      if (seenKomaIds.has(koma.id)) {
+        // 合同授業の2番目以降のクラス
+        cells.push("spanned")
+        continue
+      }
+
+      seenKomaIds.add(koma.id)
+
+      const assignedClassIds =
+        koma.komaClasses?.map((kc) => kc.classId) ?? []
+      const indices = assignedClassIds
+        .map((cid) => gradeClasses.findIndex((c) => c.id === cid))
+        .filter((idx) => idx >= 0)
+        .sort((a, b) => a - b)
+
+      // colSpan: 連続するインデックスの数を数える
+      let colSpan = 1
+      if (indices.length > 1) {
+        // 最小インデックスから連続する数
+        for (let k = 1; k < indices.length; k++) {
+          if (indices[k] === indices[k - 1] + 1) {
+            colSpan++
+          } else {
+            break
+          }
+        }
+      }
+
+      const teachers: TeacherDisplay[] = (koma.komaTeachers ?? [])
+        .map((kt) => ({
+          teacherId: kt.teacherId,
+          name: kt.teacher?.name ?? "不明",
+          role: kt.role as "main" | "sub",
+        }))
+        .sort((a, b) => (a.role === "main" ? -1 : 1) - (b.role === "main" ? -1 : 1))
+
+      cells.push({
+        komaId: koma.id,
+        classIds:
+          assignedClassIds.length > 0
+            ? assignedClassIds
+            : [gradeClasses[i]?.id].filter(Boolean),
+        teachers,
+        colSpan,
+      })
+    }
+
+    rows.push({
+      subjectId,
+      subjectName: group.subject.name,
+      subjectColor: group.subject.color,
+      hours,
+      cells,
+      komaIds: group.komas.map((k) => k.id),
+    })
+  }
+
+  // sortOrder でソート
+  const subjectOrder = new Map(subjects.map((s) => [s.id, s.sortOrder]))
+  rows.sort(
+    (a, b) =>
+      (subjectOrder.get(a.subjectId) ?? 999) -
+      (subjectOrder.get(b.subjectId) ?? 999)
+  )
+
+  return rows
+}

--- a/lib/solver/localSearch.ts
+++ b/lib/solver/localSearch.ts
@@ -125,7 +125,7 @@ export function tabuSearch(
         phase: "localSearch",
         phaseLabel: "局所探索",
         score: bestScore,
-        message: `リスタート${restartCount}/${maxRestarts}, best=${bestScore}`,
+        message: `リスタート ${restartCount}/${maxRestarts}回目 ｜ 最良スコア ${bestScore}`,
       })
     }
 
@@ -142,8 +142,8 @@ export function tabuSearch(
         phaseLabel: "局所探索",
         placedCount: assignments.length,
         score: bestScore,
-        violations: bestScore,
-        message: `探索: iter=${iteration}, best=${bestScore}, current=${vi.totalScore}`,
+        violations: 0,
+        message: `${iteration.toLocaleString()}手探索済み ｜ 探索中スコア ${vi.totalScore.toLocaleString()}`,
       })
     }
   }

--- a/lib/solver/scheduler.ts
+++ b/lib/solver/scheduler.ts
@@ -1,10 +1,12 @@
 import type { ConstraintContext } from "./constraints"
 import {
   evaluateAllConstraints,
-  calculateScore,
+  calculateScoreFast,
+  computeKomaPlacementCost,
   setTeacherCache,
 } from "./constraints"
 import { greedyConstruct } from "./greedyConstruct"
+import { addToMaps } from "./incrementalMaps"
 import { tabuSearch } from "./localSearch"
 import { SeededRandom } from "./random"
 import {
@@ -18,6 +20,8 @@ import {
 } from "./utils"
 import type {
   Assignment,
+  KomaLookup,
+  SlotPosition,
   SolverConfig,
   SolverInput,
   SolverProgress,
@@ -69,8 +73,24 @@ export class TimetableScheduler {
       }
     }
 
+    // 全パターンのスコア一覧を記録
+    const allPatternScores = results.map((r, i) => ({
+      index: i + 1,
+      score: r.score,
+      violations: r.violations.length,
+    }))
+
     results.sort((a, b) => a.score - b.score)
-    return results[0]
+    const best = results[0]
+    const selectedIndex = results.indexOf(best)
+
+    return {
+      ...best,
+      allPatternScores,
+      selectedPatternIndex: allPatternScores.findIndex(
+        (p) => p.score === best.score
+      ),
+    }
   }
 
   private async solveOne(
@@ -172,16 +192,52 @@ export class TimetableScheduler {
       tabuDeadline
     )
 
+    // ── Phase 2.5: 重複除去 + 未配置コマ補充 ──
+    const deduped = deduplicateAssignments(bestAssignments)
+
+    // マップ再構築（タブー探索後の ctx マップは最終解と一致しない）
+    for (const k of Object.keys(ctx.teacherMap)) delete ctx.teacherMap[k]
+    for (const k of Object.keys(ctx.classMap)) delete ctx.classMap[k]
+    for (const k of Object.keys(ctx.roomMap)) delete ctx.roomMap[k]
+    const rebuilt = buildScheduleMaps(deduped, komaLookup)
+    Object.assign(ctx.teacherMap, rebuilt.teacherMap)
+    Object.assign(ctx.classMap, rebuilt.classMap)
+    Object.assign(ctx.roomMap, rebuilt.roomMap)
+
+    const filledAssignments = fillMissingAssignments(
+      ctx,
+      deduped,
+      targets,
+      komaLookup,
+      allPositions
+    )
+
+    sendProgress({
+      phase: "construction",
+      phaseLabel: "未配置補充完了",
+      placedCount: filledAssignments.length,
+      message: `補充完了: ${filledAssignments.length}/${totalKomas}コマ`,
+    })
+
     // ── Phase 3: 最終評価 ──
-    const violations = evaluateAllConstraints(ctx, bestAssignments)
-    const score = calculateScore(violations)
+    // 違反の詳細リストを取得（UI表示用）
+    const violations = evaluateAllConstraints(ctx, filledAssignments)
+    // スコアは calculateScoreFast（タブー探索と同じ computeKomaPlacementCost ベース）
+    // + 未配置コマペナルティで統一（evaluateAllConstraints のスコアズレを防止）
+    const scoreMapData = buildScheduleMaps(filledAssignments, komaLookup)
+    const scoreCtx: ConstraintContext = { ...ctx, ...scoreMapData }
+    let score = calculateScoreFast(scoreCtx, filledAssignments)
+    for (const v of violations) {
+      if (v.type === "unplaced") score += v.weight
+    }
 
     return {
-      assignments: bestAssignments,
+      assignments: filledAssignments,
       violations,
       score,
       elapsedMs: Date.now() - this.startTime,
-      isComplete: bestAssignments.length >= totalKomas && score === 0,
+      isComplete:
+        checkAllKomasPlaced(filledAssignments, targets) && score === 0,
     }
   }
 
@@ -208,4 +264,95 @@ export class TimetableScheduler {
       elapsedMs: Date.now() - this.startTime,
     }
   }
+}
+
+// ── ヘルパー関数 ──
+
+function deduplicateAssignments(assignments: Assignment[]): Assignment[] {
+  const seen = new Set<string>()
+  const result: Assignment[] = []
+  for (const a of assignments) {
+    const key = `${a.komaId}:${a.dayOfWeek}:${a.period}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      result.push(a)
+    }
+  }
+  return result
+}
+
+function fillMissingAssignments(
+  ctx: ConstraintContext,
+  assignments: Assignment[],
+  targets: { komaId: string; index: number }[],
+  komaLookup: KomaLookup,
+  allPositions: SlotPosition[]
+): Assignment[] {
+  const result = [...assignments]
+
+  const placedCount = new Map<string, number>()
+  for (const a of result) {
+    placedCount.set(a.komaId, (placedCount.get(a.komaId) ?? 0) + 1)
+  }
+
+  const requiredCount = new Map<string, number>()
+  for (const t of targets) {
+    requiredCount.set(
+      t.komaId,
+      Math.max(requiredCount.get(t.komaId) ?? 0, t.index + 1)
+    )
+  }
+
+  for (const [komaId, required] of requiredCount) {
+    let placed = placedCount.get(komaId) ?? 0
+    while (placed < required) {
+      let bestPos: SlotPosition | null = null
+      let bestCost = Infinity
+
+      for (const pos of allPositions) {
+        const cost = computeKomaPlacementCost(ctx, komaId, pos)
+        if (cost < bestCost) {
+          bestCost = cost
+          bestPos = pos
+        }
+      }
+
+      if (bestPos) {
+        result.push({
+          komaId,
+          dayOfWeek: bestPos.dayOfWeek,
+          period: bestPos.period,
+        })
+        addToMaps(ctx, komaLookup, komaId, bestPos)
+        placed++
+      } else {
+        break
+      }
+    }
+  }
+
+  return result
+}
+
+function checkAllKomasPlaced(
+  assignments: Assignment[],
+  targets: { komaId: string; index: number }[]
+): boolean {
+  const placedCount = new Map<string, number>()
+  for (const a of assignments) {
+    placedCount.set(a.komaId, (placedCount.get(a.komaId) ?? 0) + 1)
+  }
+
+  const requiredCount = new Map<string, number>()
+  for (const t of targets) {
+    requiredCount.set(
+      t.komaId,
+      Math.max(requiredCount.get(t.komaId) ?? 0, t.index + 1)
+    )
+  }
+
+  for (const [komaId, required] of requiredCount) {
+    if ((placedCount.get(komaId) ?? 0) < required) return false
+  }
+  return true
 }

--- a/lib/solver/types.ts
+++ b/lib/solver/types.ts
@@ -97,6 +97,9 @@ export interface SolverResult {
   score: number
   elapsedMs: number
   isComplete: boolean
+  // 全パターンのスコア一覧（採用パターンのインデックス付き）
+  allPatternScores?: { index: number; score: number; violations: number }[]
+  selectedPatternIndex?: number
 }
 
 // Worker メッセージ型

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -273,6 +273,8 @@ model PerSubjectCondition {
   conditionId          String
   condition            ScheduleCondition @relation(fields: [conditionId], references: [id], onDelete: Cascade)
   subjectId            String
+  // 制約レベル: "forbidden" | "consider" | "ignore"
+  level                String            @default("consider")
   // 教科別の配置制限: "any" | "morning_only" | "afternoon_only" | "not_first" | "not_last"
   placementRestriction String            @default("any")
   // 最大連続禁止

--- a/types/common.types.ts
+++ b/types/common.types.ts
@@ -199,6 +199,7 @@ export interface PerSubjectCondition {
   id: string
   conditionId: string
   subjectId: string
+  level: string // "forbidden" | "consider" | "ignore"
   placementRestriction: string
   maxPerDay: number
   createdAt: string

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -213,6 +213,7 @@ export interface ElectronAPI {
   conditionUpsertPerSubject: (data: {
     conditionId: string
     subjectId: string
+    level?: string
     placementRestriction?: string
     maxPerDay?: number
   }) => Promise<import("./common.types").PerSubjectCondition>


### PR DESCRIPTION
## Summary
- ソルバー制約エンジンにHARD_COST(100000)定数とresolveWeight関数を導入し、forbidden制約のハードペナルティを統一適用
- PerSubjectConditionにlevelフィールド(forbidden/consider/ignore)を追加し、教科別の制約制御を強化
- 駒管理ページを5コンポーネントに分割リファクタリングし、lessonGrid.tsにデータ変換ロジックを分離
- 条件設定UI・ソルバー進捗表示・結果サマリーの改善

Closes #17

## 変更ファイル（25ファイル、+2375/-1153行）

### ソルバーエンジン
- `lib/solver/constraints.ts` - HARD_COST定数・resolveWeight関数追加、全制約に適用
- `lib/solver/scheduler.ts` - マルチパターン結果スコア対応
- `lib/solver/greedyConstruct.ts` - 貪欲法改善
- `lib/solver/localSearch.ts` - ローカルサーチ改善
- `lib/solver/types.ts` - allPatternScores型追加

### スキーマ・バックエンド
- `prisma/schema.prisma` - PerSubjectCondition.level追加
- `types/common.types.ts` - level型追加
- `types/electron.d.ts` - IPC型更新
- `electron-src/lib/prisma/condition.ts` - DAL更新
- `electron-src/ipc-handlers/conditionHandlers.ts` - IPCハンドラ更新

### UI
- `components/scheduler/ConditionTable.tsx` - 禁止/無視時の重み固定表示
- `components/scheduler/PerSubjectSection.tsx` - 新規インラインセクション
- `components/scheduler/SolverProgress.tsx` - 最良スコア表示
- `components/scheduler/SolverResultSummary.tsx` - 全パターン結果一覧
- `app/scheduler/conditions/page.tsx` - レイアウト変更

### 駒管理リファクタリング
- `components/lesson/LessonTable.tsx` - メインテーブル（新規）
- `components/lesson/PresetDialog.tsx` - プリセットダイアログ（新規）
- `components/lesson/KomaDetailDialog.tsx` - 詳細ダイアログ（新規）
- `components/lesson/TeacherCell.tsx` - 教員セル（新規）
- `components/lesson/TeacherSelectDialog.tsx` - 教員選択ダイアログ（新規）
- `lib/lessonGrid.ts` - スプレッドシートデータ変換（新規）
- `app/data/koma/page.tsx` - リファクタリング後のページ

## Test plan
- [ ] `npm run build` がエラーなく完了すること
- [ ] 条件設定ページで禁止/考慮/無視の切替と重み表示が正しく動作すること
- [ ] 教科別条件のlevel設定が保存・反映されること
- [ ] ソルバー実行時にHARD_COSTが正しく適用されること
- [ ] 駒管理ページのLessonTableが正常に表示・操作できること
- [ ] 全パターン結果がSolverResultSummaryに表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)